### PR TITLE
Extracting profile data. Respecting options[:redirect_uri].

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ test/tmp
 test/version_tmp
 tmp
 .powenv
+vendor/bundle

--- a/lib/omniauth/strategies/google_oauth2.rb
+++ b/lib/omniauth/strategies/google_oauth2.rb
@@ -19,7 +19,7 @@ module OmniAuth
       def setup_authorize_params
         opts = {
           :client_id => options[:client_id],
-          :redirect_uri => callback_url,
+          :redirect_uri => options[:redirect_uri] || callback_url,
           :response_type => "code",
           :scope => options[:scope]
         }

--- a/spec/omniauth/strategies/google_oauth2_spec.rb
+++ b/spec/omniauth/strategies/google_oauth2_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 require 'omniauth-google-oauth2'
 
 describe OmniAuth::Strategies::GoogleOauth2 do
+
   subject do
     OmniAuth::Strategies::GoogleOauth2.new(nil, @options || {})
   end
@@ -19,6 +20,23 @@ describe OmniAuth::Strategies::GoogleOauth2 do
 
     it 'has correct token url' do
       subject.client.options[:token_url].should eq('/o/oauth2/token')
+    end
+  end
+
+  describe 'redirect_uri' do
+    before do
+      subject.stub(:callback_url).and_return('http://example.host/default')
+    end
+
+    it 'should be callback_url by default' do
+      subject.request_phase
+      subject.options[:authorize_params][:redirect_uri].should eql('http://example.host/default')
+    end
+    
+    it 'should be overriden by an option' do
+      subject.options[:redirect_uri] = 'http://example.host/override'
+      subject.request_phase
+      subject.options[:authorize_params][:redirect_uri].should eql('http://example.host/override')
     end
   end
 


### PR DESCRIPTION
Hi Josh, 

finally here comes the pull request for the change(s) I made. 
First I enhanced google_oauth2 to include a call to the profile api endpoint to retrieve all user_data, not just the email address. I also adapted the key to info (instead of user_info) as it's required by new omniauth 1.0

This call to profile api will always take place and always succeeds as it delievers the public profile data, even if the profile scope is not set. 

Second i fixed what i consider a bug. At least omniauth and google_oauth2 did not work together very well here. It turned out that the redirect_uri was not taken into account correctly, instead omniauth's callback_url was used. Omniauth set the host of that redirect_uri the wrong in my development environment when it came to the final authentication call to google.

Hope this fix is helpful

Christian
