### PR TITLE
Obtaining basic user profile information

### DIFF
--- a/lib/omniauth/strategies/google_oauth2.rb
+++ b/lib/omniauth/strategies/google_oauth2.rb
@@ -3,58 +3,58 @@ require 'omniauth/strategies/oauth2'
 module OmniAuth
   module Strategies
     class GoogleOauth2 < OmniAuth::Strategies::OAuth2
+
+      # Possible scopes: userinfo.email,userinfo.profile,plus.me
+      DEFAULT_SCOPE = "userinfo.email"
+
       option :name, 'google_oauth2'
 
       option :client_options, {
-        :site => 'https://accounts.google.com',
+        :site          => 'https://accounts.google.com',
         :authorize_url => '/o/oauth2/auth',
-        :token_url => '/o/oauth2/token'
+        :token_url     => '/o/oauth2/token'
       }
 
-      def request_phase
-        setup_authorize_params
-        super
+      def authorize_params
+        base_scope_url = "https://www.googleapis.com/auth/"
+        super.tap do |params|
+          scopes = (params[:scope] || DEFAULT_SCOPE).split(",")
+          scopes.map! { |s| s =~ /^https?:\/\// ? s : "#{base_scope_url}#{s}" }
+          params[:scope] = scopes.join(' ')
+        end
       end
 
-      def setup_authorize_params
-        opts = {
-          :client_id => options[:client_id],
-          :redirect_uri => options[:redirect_uri] || callback_url,
-          :response_type => "code",
-          :scope => options[:scope]
-        }
-        google_email_scope = "www.googleapis.com/auth/userinfo.email"
-        opts[:scope] ||= "https://#{google_email_scope}"
-        opts[:scope] << " https://#{google_email_scope}" unless opts[:scope] =~ %r[http[s]?:\/\/#{google_email_scope}]
-        options[:authorize_params] = opts.merge(options[:authorize_params])
-      end
+      uid{ raw_info['id'] }
 
-      def auth_hash
-        OmniAuth::Utils.deep_merge(super, {
-          'uid' => info['uid'],
-          'info' => info,
-          'credentials' => {'expires_at' => access_token.expires_at},
-          'extra' => {'user_hash' => user_data}
+      info do
+        prune!({
+          :name       => raw_info['name'],
+          :email      => raw_info['verified_email'] ? raw_info['email'] : nil,
+          :first_name => raw_info['given_name'],
+          :last_name  => raw_info['family_name'],
+          :image      => raw_info['picture']
         })
       end
 
-      info do
-        if user_data['data']['isVerified']
-          email = user_data['data']['email'] rescue nil
-        else
-          email = nil
+      extra do
+        prune!({
+          'raw_info' => raw_info
+        })
+      end
+
+      def raw_info
+        @raw_info ||= access_token.get('https://www.googleapis.com/oauth2/v1/userinfo').parsed
+      end
+
+      private
+
+      def prune!(hash)
+        hash.delete_if do |_, value|
+          prune!(value) if value.is_a?(Hash)
+          value.nil? || (value.respond_to?(:empty?) && value.empty?)
         end
-
-        {
-          'email' => email,
-          'uid' => email,
-          'name' => email
-        }
       end
 
-      def user_data
-        @data ||= access_token.get("https://www.googleapis.com/userinfo/email?alt=json").parsed
-      end
     end
   end
 end

--- a/spec/omniauth/strategies/google_oauth2_spec.rb
+++ b/spec/omniauth/strategies/google_oauth2_spec.rb
@@ -22,34 +22,32 @@ describe OmniAuth::Strategies::GoogleOauth2 do
     end
   end
 
-  describe 'redirect_uri' do
-    before do
-      subject.stub(:callback_url).and_return('http://example.host/default')
-    end
-
-    it 'should be callback_url by default' do
-      subject.request_phase
-      subject.options[:authorize_params][:redirect_uri].should eql('http://example.host/default')
-    end
-    
-    it 'should be overriden by an option' do
-      subject.options[:redirect_uri] = 'http://example.host/override'
-      subject.request_phase
-      subject.options[:authorize_params][:redirect_uri].should eql('http://example.host/override')
-    end
-  end
-
   describe '#callback_path' do
     it "has the correct callback path" do
       subject.callback_path.should eq('/auth/google_oauth2/callback')
     end
   end
 
-  # These are setup during the request_phase
-  # At init they are blank
   describe '#authorize_params' do
-    it "has no authorize params at init" do
-      subject.authorize_params.should be_empty
+    it 'should expand scope shortcuts' do
+      @options = { :authorize_options => [:scope], :scope => 'userinfo.email'}
+      subject.authorize_params['scope'].should eq('https://www.googleapis.com/auth/userinfo.email')
+    end
+
+    it 'should leave full scopes as is' do
+      @options = { :authorize_options => [:scope], :scope => 'https://www.googleapis.com/auth/userinfo.profile'}
+      subject.authorize_params['scope'].should eq('https://www.googleapis.com/auth/userinfo.profile')
+    end
+
+    it 'should join scopes' do
+      @options = { :authorize_options => [:scope], :scope => 'userinfo.profile,userinfo.email'}
+      subject.authorize_params['scope'].should eq('https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/userinfo.email')
+    end
+
+    it 'should set default scope to userinfo.email' do
+      @options = { :authorize_options => [:scope]}
+      subject.authorize_params['scope'].should eq('https://www.googleapis.com/auth/userinfo.email')
     end
   end
+
 end

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -15,8 +15,8 @@ shared_examples 'an oauth2 strategy' do
     end
 
     it 'should include top-level options that are marked as :authorize_options' do
-      @options = { :authorize_options => [:scope, :foo], :scope => 'bar', :foo => 'baz' }
-      subject.authorize_params['scope'].should eq('bar')
+      @options = { :authorize_options => [:scope, :foo], :scope => 'http://bar', :foo => 'baz' }
+      subject.authorize_params['scope'].should eq('http://bar')
       subject.authorize_params['foo'].should eq('baz')
     end
   end


### PR DESCRIPTION
- Scope shortcuts: 'userinfo.profile' expands to
  'https://www.googleapis.com/auth/userinfo.profile'
- Multiple scopes separated by comman can be specified
- Returns name, first_name, last_name, image, email in info
  with `:scope => 'userinfo.email,userinfo.profile'`
- Extra also contains gender and locale
