### PR TITLE
The authorize params: access_type and approval_prompt should be configurable form outside

### DIFF
--- a/lib/omniauth/strategies/google_oauth2.rb
+++ b/lib/omniauth/strategies/google_oauth2.rb
@@ -8,6 +8,7 @@ module OmniAuth
       DEFAULT_SCOPE = "userinfo.email,userinfo.profile"
 
       option :name, 'google_oauth2'
+      option :authorize_options, [:scope, :approval_prompt, :access_type]
 
       option :client_options, {
         :site          => 'https://accounts.google.com',
@@ -23,8 +24,8 @@ module OmniAuth
           params[:scope] = scopes.join(' ')
           # This makes sure we get a refresh_token.
           # http://googlecode.blogspot.com/2011/10/upcoming-changes-to-oauth-20-endpoint.html
-          params[:access_type] = 'offline'
-          params[:approval_prompt] = 'force'
+          params[:access_type] = 'offline' if params[:access_type].nil?
+          params[:approval_prompt] = 'force' if params[:approval_prompt].nil?
         end
       end
 


### PR DESCRIPTION
params[:approval_prompt] = 'force'
is forceing to show google auth approval prompt even if application already have this approval

In my case, I used Devise+OmniAuth+omniauth-google-oauth2, and with this patch I been able to configure the approval_prompt in my devise.rb config:

config.omniauth :google_oauth2, 'client_id_here', 'client_secret_here', {
  :scope => 'the_scope_here',
  :approval_prompt => 'force'
}

If someon don't need approval always but only at first time, he can set:
:approval_prompt => ''

Best Regards,
Konrad.
