### PR TITLE
Read the params if passed directly to omniauth_authorize_path

### DIFF
--- a/lib/omniauth/strategies/google_oauth2.rb
+++ b/lib/omniauth/strategies/google_oauth2.rb
@@ -20,8 +20,8 @@ module OmniAuth
         base_scope_url = "https://www.googleapis.com/auth/"
         super.tap do |params|
           # Read the params if passed directly to omniauth_authorize_path
-          %w(scope access_type approval_prompt hd).each do |k|
-            params[k.to_sym] = request.params[k] if request.params[k].present?
+          @options.authorize_options.each do |k|
+            params[k] = request.params[k.to_s] if request.params.has_key?(k.to_s)
           end
           scopes = (params[:scope] || DEFAULT_SCOPE).split(",")
           scopes.map! { |s| s =~ /^https?:\/\// ? s : "#{base_scope_url}#{s}" }

--- a/spec/omniauth/strategies/google_oauth2_spec.rb
+++ b/spec/omniauth/strategies/google_oauth2_spec.rb
@@ -3,6 +3,14 @@ require 'omniauth-google-oauth2'
 
 describe OmniAuth::Strategies::GoogleOauth2 do
 
+  before do
+    OmniAuth.config.test_mode = true
+  end
+
+  after do
+    OmniAuth.config.test_mode = false
+  end
+
   before :each do
     @request = double('Request')
     @request.stub(:params) { {} }
@@ -80,6 +88,15 @@ describe OmniAuth::Strategies::GoogleOauth2 do
       @options = {:hd => "example.com"}
       subject.authorize_params['hd'].should eq('example.com')
     end
+
+    it 'should override the params when specified in the request' do
+      @options = {:scope => 'userinfo.profile'}
+      subject.stub_chain(:request, :params).and_return({
+        'scope' => 'http://www.google.com/m8/feeds',
+      })
+      subject.authorize_params['scope'].should eq('http://www.google.com/m8/feeds')
+    end
+
   end
 
 end


### PR DESCRIPTION
Little fix to make `authorize_params` behave like the other strategies (like facebook, for example) reading the params form the request if present.
