### PR TITLE
Fix: don't request userinfo unless proper scope present

### DIFF
--- a/lib/omniauth/strategies/google_oauth2.rb
+++ b/lib/omniauth/strategies/google_oauth2.rb
@@ -54,6 +54,7 @@ module OmniAuth
       end
 
       def raw_info
+        return {} unless (options.scope || DEFAULT_SCOPE).index(/\Auserinfo/)
         @raw_info ||= access_token.get('https://www.googleapis.com/oauth2/v1/userinfo').parsed
       end
 


### PR DESCRIPTION
When overriding the scope option to not include `userinfo.profile` or `userinfo.email`, the strategy attempts to request the userinfo anyways causing an `OAuth2:Error: Invalid Credentials`. This patch checks the scope before attempting to request the userinfo fixing the issue.
