### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # OmniAuth Google OAuth2 Strategy
 
-Strategy to auth with Google via OAuth2 in OmniAuth.
+Strategy to authenticate with Google via OAuth2 in OmniAuth.
 
-Get your API key at https://code.google.com/apis/console/
+Get your API key at: https://code.google.com/apis/console/ .
 
-## Installing
+For more details, read the Google docs: https://developers.google.com/accounts/docs/OAuth2 .
+
+## Installation
 
 Add to your `Gemfile`:
 
@@ -16,21 +18,77 @@ Then `bundle install`.
 
 ## Usage
 
-Add the middleware to a Rails app in `config/initializers/omniauth.rb`:
+Here's an example, adding the middleware to a Rails app in `config/initializers/omniauth.rb`:
 
 ```ruby
 Rails.application.config.middleware.use OmniAuth::Builder do
-  provider :google_oauth2, "CLIENT_ID", "CLIENT_SECRET"
+  provider :google_oauth2, ENV["GOOGLE_KEY"], ENV["GOOGLE_SECRET"]
 end
 ```
 
-Auth Url is: /auth/google_oauth2
+You can now access the OmniAuth Google OAuth2 URL: `/auth/google_oauth2`.
 
-## Tips on the scope parameter
+## Configuration
 
-* You don't need the https://www.googleapis.com/auth/ prefix.
-* You provide a comma separated list, without spaces. 
-* You need to give userinfo.email to get the email.
+You can configure several options, which you pass in to the `provider` method via a hash:
+
+* `scope`: A comma-separated list, without spaces, of permissions you want to request from the user. See the [Google OAuth 2.0 Playground](https://developers.google.com/oauthplayground/) for a full list of available permissions. Caveats:
+  * The `userinfo.email` and `userinfo.profile` scopes are used by default. By defining your own `scope`, you override these defaults. If you need these scopes, don't forget to add them yourself!
+  * Scopes starting with `https://www.googleapis.com/auth/` do not need that prefix specified. So while you should use the smaller scope `books` since that permission starts with the mentioned prefix, you should use the full scope URL `https://docs.google.com/feeds/` to access a user's docs, for example.
+* `approval_prompt`: Determines whether the user is always re-prompted for consent. It's set to `force` by default so a user sees a consent page even if he has previously allowed access a given set of scopes. Set this value to `auto` so that the user only sees the consent page the first time he authorizes a given set of scopes.
+* `access_type`: Defaults to `offline`, so a refresh token is sent to be used when the user is not present at the browser. Can be set to `online`.
+
+Here's an example of a possible configuration where the user is asked for extra permissions and is only prompted once for such permissions:
+
+```ruby
+Rails.application.config.middleware.use OmniAuth::Builder do
+  provider :facebook, ENV["GOOGLE_KEY"], ENV["GOOGLE_SECRET"],
+           {
+             :scope => "userinfo.email,userinfo.profile,plus.me,http://gdata.youtube.com",
+             :approval_prompt => "auto"
+           }
+end
+```
+
+## Auth Hash
+
+Here's an example of an authentication hash available in the callback by accessing `request.env["omniauth.auth"]`:
+
+```ruby
+{
+    :provider => "google_oauth2",
+    :uid => "123456789",
+    :info => {
+        :name => "John Doe",
+        :email => "john@company_name.com",
+        :first_name => "John",
+        :last_name => "Doe",
+        :image => "https://lh3.googleusercontent.com/url/photo.jpg"
+    },
+    :credentials => {
+        :token => "token",
+        :refresh_token => "another_token",
+        :expires_at => 1354920555,
+        :expires => true
+    },
+    :extra => {
+        :raw_info => {
+            :id => "123456789",
+            :email => "user@domain.example.com",
+            :verified_email => true,
+            :name => "John Doe",
+            :given_name => "John",
+            :family_name => "Doe",
+            :link => "https://plus.google.com/123456789",
+            :picture => "https://lh3.googleusercontent.com/url/photo.jpg",
+            :gender => "male",
+            :birthday => "0000-06-25",
+            :locale => "en",
+            :hd => "company_name.com"
+        }
+    }
+}
+```
 
 ## License
 


### PR DESCRIPTION
I know that the `approval_prompt` and `access_type` params can be set to empty strings (anything other than nil, really) but I defined a specific value, according to [Google's documentation](https://developers.google.com/accounts/docs/OAuth2WebServer#formingtheurl). Hope you don't mind. Maybe you could even change this in the future to match the spec?
