### PR TITLE
set any other authorize option dynamically in the request

### DIFF
--- a/lib/omniauth/strategies/google_oauth2.rb
+++ b/lib/omniauth/strategies/google_oauth2.rb
@@ -20,8 +20,8 @@ module OmniAuth
         base_scope_url = "https://www.googleapis.com/auth/"
         super.tap do |params|
           # Read the params if passed directly to omniauth_authorize_path
-          %w(scope approval_prompt access_type state hd).each do |k|
-            params[k.to_sym] = request.params[k] unless [nil, ''].include?(request.params[k])
+          options[:authorize_options].each do |k|
+            params[k] = request.params[k.to_s] unless [nil, ''].include?(request.params[k.to_s])
           end
           scopes = (params[:scope] || DEFAULT_SCOPE).split(",")
           scopes.map! { |s| s =~ /^https?:\/\// ? s : "#{base_scope_url}#{s}" }

--- a/spec/omniauth/strategies/google_oauth2_spec.rb
+++ b/spec/omniauth/strategies/google_oauth2_spec.rb
@@ -46,9 +46,9 @@ describe OmniAuth::Strategies::GoogleOauth2 do
   end
 
   describe '#authorize_params' do
-    %w(approval_prompt access_type state hd).each do |k|
+    %w(approval_prompt access_type state hd any_other).each do |k|
       it "should set the #{k} authorize option dynamically in the request" do
-        @options = {k.to_sym => ''}
+        @options = {:authorize_options => [k.to_sym], k.to_sym => ''}
         subject.stub(:request) { double('Request', {:params => { k => 'something' }, :env => {}}) }
         subject.authorize_params[k].should eq('something')
       end


### PR DESCRIPTION
This allows to set any other authorize option dynamically in the request.
