### PR TITLE
Changed approval_prompt to prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,17 +35,23 @@ You can configure several options, which you pass in to the `provider` method vi
 * `scope`: A comma-separated list of permissions you want to request from the user. See the [Google OAuth 2.0 Playground](https://developers.google.com/oauthplayground/) for a full list of available permissions. Caveats:
   * The `userinfo.email` and `userinfo.profile` scopes are used by default. By defining your own `scope`, you override these defaults. If you need these scopes, don't forget to add them yourself!
   * Scopes starting with `https://www.googleapis.com/auth/` do not need that prefix specified. So while you should use the smaller scope `books` since that permission starts with the mentioned prefix, you should use the full scope URL `https://docs.google.com/feeds/` to access a user's docs, for example.
-* `approval_prompt`: Determines whether the user is always re-prompted for consent. It's set to `force` by default so a user sees a consent page even if he has previously allowed access a given set of scopes. Set this value to `auto` so that the user only sees the consent page the first time he authorizes a given set of scopes.
+* `prompt`: A space-delimited list of string values that determines whether the user is re-prompted for authentication and/or consent. Possible values are:
+  * `none`: No authentication or consent pages will be displayed; it will return an error if the user is not already authenticated and has not pre-configured consent for the requested scopes. This can be used as a method to check for existing authentication and/or consent.
+  * `consent`: The user will always be prompted for consent, even if he has previously allowed access a given set of scopes.
+  * `select_account`: The user will always be prompted to select a user account. This allows a user who has multiple current account sessions to select one amongst them.
+
+  If no value is specified, the user only sees the authentication page if he is not logged in and only sees the consent page the first time he authorizes a given set of scopes.
+
 * `access_type`: Defaults to `offline`, so a refresh token is sent to be used when the user is not present at the browser. Can be set to `online`.
 
-Here's an example of a possible configuration where the user is asked for extra permissions and is only prompted once for such permissions:
+Here's an example of a possible configuration where the user is asked for extra permissions and is always prompted to select his account when logging in:
 
 ```ruby
 Rails.application.config.middleware.use OmniAuth::Builder do
   provider :google_oauth2, ENV["GOOGLE_KEY"], ENV["GOOGLE_SECRET"],
            {
              :scope => "userinfo.email, userinfo.profile, plus.me, http://gdata.youtube.com",
-             :approval_prompt => "auto"
+             :prompt => "consent select_account"
            }
 end
 ```

--- a/lib/omniauth/strategies/google_oauth2.rb
+++ b/lib/omniauth/strategies/google_oauth2.rb
@@ -7,7 +7,8 @@ module OmniAuth
       DEFAULT_SCOPE = "userinfo.email,userinfo.profile"
 
       option :name, 'google_oauth2'
-      option :authorize_options, [:scope, :approval_prompt, :access_type, :state, :hd, :request_visible_actions]
+
+      option :authorize_options, [:access_type, :hd, :prompt, :request_visible_actions, :scope, :state]
 
       option :client_options, {
         :site          => 'https://accounts.google.com',
@@ -28,7 +29,6 @@ module OmniAuth
           # This makes sure we get a refresh_token.
           # http://googlecode.blogspot.com/2011/10/upcoming-changes-to-oauth-20-endpoint.html
           params[:access_type] = 'offline' if params[:access_type].nil?
-          params[:approval_prompt] = 'force' if params[:approval_prompt].nil?
           params[:login_hint] = request.params['login_hint'] if request.params['login_hint']
           # Override the state per request
           session['omniauth.state'] = params[:state] if request.params['state']

--- a/spec/omniauth/strategies/google_oauth2_spec.rb
+++ b/spec/omniauth/strategies/google_oauth2_spec.rb
@@ -46,7 +46,7 @@ describe OmniAuth::Strategies::GoogleOauth2 do
   end
 
   describe '#authorize_params' do
-    %w(approval_prompt access_type state hd any_other).each do |k|
+    %w(access_type hd prompt state any_other).each do |k|
       it "should set the #{k} authorize option dynamically in the request" do
         @options = {:authorize_options => [k.to_sym], k.to_sym => ''}
         subject.stub(:request) { double('Request', {:params => { k => 'something' }, :env => {}}) }
@@ -87,15 +87,10 @@ describe OmniAuth::Strategies::GoogleOauth2 do
       end
     end
 
-    describe 'approval_prompt' do
-      it 'should set the approval_prompt parameter if present' do
-        @options = {:approval_prompt => 'prompt'}
-        subject.authorize_params['approval_prompt'].should eq('prompt')
-      end
-
-      it 'should default to "force"' do
-        @options = {}
-        subject.authorize_params['approval_prompt'].should eq('force')
+    describe 'prompt' do
+      it 'should set the prompt parameter if present' do
+        @options = {:prompt => 'consent select_account'}
+        subject.authorize_params['prompt'].should eq('consent select_account')
       end
     end
 


### PR DESCRIPTION
The param `approval_prompt` only allowed 2 options and `prompt` has a lot more flexibility as you can see [here](https://developers.google.com/accounts/docs/OAuth2Login#authenticationuriparameters). Basically:
- `approval_prompt: 'force'` = `prompt: 'consent'`
- `approval_prompt: 'auto'` = not passing any value to `prompt`

And now there are a couple more options:
- `prompt: 'none'`: No authentication or consent pages will be displayed; it will return an error if the user is not already authenticated and has not pre-configured consent for the requested scopes. This can be used as a method to check for existing authentication and/or consent.
- `prompt: 'select_account'`: The user will always be prompted to select a user account. This allows a user who has multiple current account sessions to select one amongst them. Like this:

![gwlsa](https://f.cloud.github.com/assets/531168/662772/f35172ca-d75d-11e2-9d04-fbbdf0e02a89.png)
- `prompt: 'consent select_account'`: A combination of 2 previous options.

There are a couple issues with this pull request:
1. This gem's default value for `approval_prompt` used to be `force` but according to the Google OAuth 2 spec, the default should be `auto`. Now with `prompt` I'm respecting that default, so this is a breaking change that should probably require a bump of the gem's minor version number.
2. The list of scopes is comma-separated and I left the list of prompt values space-separated. A bit inconsistent. The thing is, making it comma-separated only complicates the `authorize_params` function. And since in the Google OAuth 2 spec, the scope and prompt values are space-separated, maybe it would be better to separate the scopes by spaces? Tell me what you think.
