### PR TITLE
Added options to change the dimensions of the user's profile picture

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ You can configure several options, which you pass in to the `provider` method vi
 
   Defaults to `original`.
 
-* `image_size`: A hash with keys `:width` and `:height` defining the size of the user's profile picture. If only `:width` or `:height` is specified, a picture whose width or height is closest to the requested size and requested aspect ratio will be returned. Defaults to the original width and height of the picture.
+* `image_size`: The size of the user's profile picture. The image returned will have width equal to the given value and variable height, according to the `image_aspect_ratio` chosen. Additionally, a picture with specific width and height can be request by setting this option to a hash with `:width` and `:height` as keys. If only `:width` or `:height` is specified, a picture whose width or height is closest to the requested size and requested aspect ratio will be returned. Defaults to the original width and height of the picture.
 
 * `access_type`: Defaults to `offline`, so a refresh token is sent to be used when the user is not present at the browser. Can be set to `online`.
 
@@ -61,9 +61,7 @@ Rails.application.config.middleware.use OmniAuth::Builder do
       :scope => "userinfo.email, userinfo.profile, plus.me, http://gdata.youtube.com",
       :prompt => "select_account",
       :image_aspect_ratio => "square",
-      :image_size => {
-        :width => 50
-      }
+      :image_size => 50
     }
 end
 ```

--- a/lib/omniauth/strategies/google_oauth2.rb
+++ b/lib/omniauth/strategies/google_oauth2.rb
@@ -90,7 +90,9 @@ module OmniAuth
         return original_url if original_url.nil? || (!options[:image_size] && !options[:image_aspect_ratio])
 
         image_params = []
-        if options[:image_size]
+        if options[:image_size].is_a?(Integer)
+          image_params << "s#{options[:image_size]}"
+        elsif options[:image_size].is_a?(Hash)
           image_params << "w#{options[:image_size][:width]}" if options[:image_size][:width]
           image_params << "h#{options[:image_size][:height]}" if options[:image_size][:height]
         end

--- a/spec/omniauth/strategies/google_oauth2_spec.rb
+++ b/spec/omniauth/strategies/google_oauth2_spec.rb
@@ -160,6 +160,14 @@ describe OmniAuth::Strategies::GoogleOauth2 do
   end
 
   describe 'image options' do
+    it 'should return the image with size specified in the `image_size` option' do
+      @options = { :image_size => 50 }
+      subject.stub(:raw_info) { { 'picture' => 'https://lh3.googleusercontent.com/url/photo.jpg' } }
+      main_url, image_params = subject.info[:image].match(/^(.*)\/(.*)\/photo.jpg/).captures
+      main_url.should eq('https://lh3.googleusercontent.com/url')
+      image_params.should eq('s50')
+    end
+
     it 'should return the image with width and height specified in the `image_size` option' do
       @options = { :image_size => { :width => 50, :height => 50 } }
       subject.stub(:raw_info) { { 'picture' => 'https://lh3.googleusercontent.com/url/photo.jpg' } }


### PR DESCRIPTION
Ok, so this feature isn't documented **anywhere** but since Google+ makes extensive use of it so that every image perfectly fits its stream layout, my feeling is that it's not going to disappear overnight. Still, since this isn't official I guess it could break someday. :unamused:

Basically, there are a bunch of options that when strung together with an hyphen `-` and added to the image url, can dynamically change the image returned. The options that I'm using in this pull request are:

`w<X>` - returns an image with width X and variable height, maintaining original aspect ratio.
`h<X>` - returns an image with height X and variable width, maintaining original aspect ratio.
`s<X>` - an alias for `w<X>`.
`c` - returns a square image.

There are a couple more that I found though:

`d` - forces the image to be downloaded.
`g` - returns an xml file containing the image's base url.

And I'm pretty sure there are a lot more options to be discovered.

With this pull request, you can get images of pretty much any size. So this is the original picture:
https://lh6.googleusercontent.com/-TrRWo7SihiM/AAAAAAAAAAI/AAAAAAAAAEs/h8rjSd_wjms/photo.jpg

This is a thumbnail:
https://lh6.googleusercontent.com/-TrRWo7SihiM/AAAAAAAAAAI/AAAAAAAAAEs/h8rjSd_wjms/s50-c/photo.jpg

``` ruby
{ :image_size => 50, :image_aspect_ratio => "square" }
```

And this is a large picture:
https://lh6.googleusercontent.com/-TrRWo7SihiM/AAAAAAAAAAI/AAAAAAAAAEs/h8rjSd_wjms/w1000-h1000/photo.jpg

``` ruby
{ :image_size => { :width => 1000, :height => 1000 }
```
