### PR TITLE
Update README with name option

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,14 +52,17 @@ You can configure several options, which you pass in to the `provider` method vi
 
 * `image_size`: The size of the user's profile picture. The image returned will have width equal to the given value and variable height, according to the `image_aspect_ratio` chosen. Additionally, a picture with specific width and height can be requested by setting this option to a hash with `width` and `height` as keys. If only `width` or `height` is specified, a picture whose width or height is closest to the requested size and requested aspect ratio will be returned. Defaults to the original width and height of the picture.
 
+* `name`: The name of the strategy. The default name is `google_oauth2` but it can be changed to any value, for example `google`. The OmniAuth URL will thus change to `/auth/google` and the `provider` key in the auth hash will then return `google`.
+
 * `access_type`: Defaults to `offline`, so a refresh token is sent to be used when the user is not present at the browser. Can be set to `online`.
 
-Here's an example of a possible configuration where the user is asked for extra permissions, the user is always prompted to select his account when logging in and the user's profile picture is returned as a thumbnail:
+Here's an example of a possible configuration where the strategy name is changed, the user is asked for extra permissions, the user is always prompted to select his account when logging in and the user's profile picture is returned as a thumbnail:
 
 ```ruby
 Rails.application.config.middleware.use OmniAuth::Builder do
   provider :google_oauth2, ENV["GOOGLE_KEY"], ENV["GOOGLE_SECRET"],
     {
+      :name => "google",
       :scope => "userinfo.email, userinfo.profile, plus.me, http://gdata.youtube.com",
       :prompt => "select_account",
       :image_aspect_ratio => "square",


### PR DESCRIPTION
[I just found out](https://github.com/intridea/omniauth/issues/581) that you can change the name of an omniauth strategy using the `name` option. And while this option is possible due to the Omniauth gem's behaviour and not this gem's, I think it should be documented here.

With other omniauth gems, most people will be satisfied with their URLs but in this gem's case the URL could look a bit better. So I think that the README should show that there's an option to change it.
