### PR TITLE
Adds user's friends to extra hash

### DIFF
--- a/lib/omniauth/strategies/google_oauth2.rb
+++ b/lib/omniauth/strategies/google_oauth2.rb
@@ -7,6 +7,8 @@ module OmniAuth
       DEFAULT_SCOPE = "userinfo.email,userinfo.profile"
 
       option :name, 'google_oauth2'
+      
+      option :skip_friends, true
 
       option :authorize_options, [:access_type, :hd, :login_hint, :prompt, :scope, :state, :redirect_uri]
 
@@ -50,11 +52,16 @@ module OmniAuth
       extra do
         hash = {}
         hash[:raw_info] = raw_info unless skip_info?
+        hash[:raw_friend_info] = raw_friend_info(raw_info['id']) unless skip_info? || options[:skip_friends]
         prune! hash
       end
 
       def raw_info
         @raw_info ||= access_token.get('https://www.googleapis.com/oauth2/v1/userinfo').parsed
+      end
+
+      def raw_friend_info(id)
+        @raw_friend_info ||= access_token.get("https://www.googleapis.com/plus/v1/people/#{id}/people/visible").parsed
       end
 
       def custom_build_access_token

--- a/spec/omniauth/strategies/google_oauth2_spec.rb
+++ b/spec/omniauth/strategies/google_oauth2_spec.rb
@@ -250,6 +250,25 @@ describe OmniAuth::Strategies::GoogleOauth2 do
     end
   end
 
+  describe 'raw friend info' do
+    it 'should not include raw friend info in extras hash by default' do
+      subject.stub(:raw_info) { {:id => '12345'} }
+      subject.extra.should_not have_key(:raw_friend_info)
+    end
+
+    it 'should not include raw friend info in extras hash when skip_info is specified to true' do
+      @options = {:skip_info => true, :skip_friends => false}
+      subject.extra.should_not have_key(:raw_friend_info)
+    end
+
+    it 'should include raw friend info in extras hash when skip_friend_info is specified to false' do
+      @options = {:skip_friends => false}
+      subject.stub(:raw_info) { {:id => '12345'} }
+      subject.stub(:raw_friend_info) { [{:foo => 'bar'}] }
+      subject.extra[:raw_friend_info].should eq([{:foo => 'bar'}])
+    end
+  end
+
   describe 'populate auth hash urls' do
     it 'should populate url map in auth hash if link present in raw_info' do
       subject.stub(:raw_info) { {'name' => 'Foo', 'link' => 'https://plus.google.com/123456'} }


### PR DESCRIPTION
Added option to populate extra hash with user's visible friends. I find myself constantly grabbing this information and figured it might be useful to have out-of-the-box if the client opts-in.
