### PR TITLE
Fix readme bug. Change `prompt` parameter to be valid

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ You can configure several options, which you pass in to the `provider` method vi
 
 * `name`: The name of the strategy. The default name is `google_oauth2` but it can be changed to any value, for example `google`. The OmniAuth URL will thus change to `/auth/google` and the `provider` key in the auth hash will then return `google`.
 
-* `access_type`: Defaults to `offline`, so a refresh token is sent to be used when the user is not present at the browser. Can be set to `online`. Note that if you need a refresh token, google requires you to also to specify the option `prompt: 'select_account consent'`, which is not a default.
+* `access_type`: Defaults to `offline`, so a refresh token is sent to be used when the user is not present at the browser. Can be set to `online`. Note that if you need a refresh token, google requires you to also to specify the option `prompt: 'consent'`, which is not a default.
 
 Here's an example of a possible configuration where the strategy name is changed, the user is asked for extra permissions, the user is always prompted to select his account when logging in and the user's profile picture is returned as a thumbnail:
 


### PR DESCRIPTION
After following the directions in the README, I think I found a bug. When using the prompt parameter specified, Google returned a 404. It was only when I changed the parameter to just `prompt: 'consent'` that Google accepted my auth request
