### PR TITLE
Add .ruby-gemset

### DIFF
--- a/.ruby-gemset
+++ b/.ruby-gemset
@@ -1,0 +1,1 @@
+omniauth-google-oauth2


### PR DESCRIPTION
This adds an rbenv-gemset (and rvm) compatible `.ruby-gemset` file.
