### PR TITLE
Change prompt to approval_prompt

### DIFF
--- a/lib/omniauth/strategies/google_oauth2.rb
+++ b/lib/omniauth/strategies/google_oauth2.rb
@@ -10,7 +10,7 @@ module OmniAuth
 
       option :skip_friends, true
 
-      option :authorize_options, [:access_type, :hd, :login_hint, :prompt, :request_visible_actions, :scope, :state, :redirect_uri]
+      option :authorize_options, [:access_type, :hd, :login_hint, :approval_prompt, :request_visible_actions, :scope, :state, :redirect_uri]
 
       option :client_options, {
         :site          => 'https://accounts.google.com',

--- a/spec/omniauth/strategies/google_oauth2_spec.rb
+++ b/spec/omniauth/strategies/google_oauth2_spec.rb
@@ -57,7 +57,7 @@ describe OmniAuth::Strategies::GoogleOauth2 do
   end
 
   describe "#authorize_options" do
-    [:access_type, :hd, :login_hint, :prompt, :scope, :state].each do |k|
+    [:access_type, :hd, :login_hint, :approval_prompt, :scope, :state].each do |k|
       it "should support #{k}" do
         @options = {k => 'http://someval'}
         subject.authorize_params[k.to_s].should eq('http://someval')
@@ -110,14 +110,14 @@ describe OmniAuth::Strategies::GoogleOauth2 do
       end
     end
 
-    describe 'prompt' do
+    describe 'approval_prompt' do
       it "should default to nil" do
-        subject.authorize_params['prompt'].should eq(nil)
+        subject.authorize_params['approval_prompt'].should eq(nil)
       end
 
-      it 'should set the prompt parameter if present' do
-        @options = {:prompt => 'consent select_account'}
-        subject.authorize_params['prompt'].should eq('consent select_account')
+      it 'should set the approval_prompt parameter if present' do
+        @options = {:approval_prompt => 'force'}
+        subject.authorize_params['approval_prompt'].should eq('force')
       end
     end
 
@@ -192,7 +192,7 @@ describe OmniAuth::Strategies::GoogleOauth2 do
       end
 
       describe "request overrides" do
-        [:access_type, :hd, :login_hint, :prompt, :scope, :state].each do |k|
+        [:access_type, :hd, :login_hint, :approval_prompt, :scope, :state].each do |k|
           context "authorize option #{k}" do
             let(:request) { double('Request', :params => {k.to_s => 'http://example.com'}, :cookies => {}, :env => {}) }
 


### PR DESCRIPTION
According to the docs at [1] there is no `prompt` parameter anymore, but
another one named `approval_prompt` which can be used forcing a consent.

[1] https://developers.google.com/accounts/docs/OAuth2WebServer
