### PR TITLE
one should be able to define include_granted_scopes parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ You can configure several options, which you pass in to the `provider` method vi
 
 * `login_hint`: When your app knows which user it is trying to authenticate, it can provide this parameter as a hint to the authentication server. Passing this hint suppresses the account chooser and either pre-fill the email box on the sign-in form, or select the proper session (if the user is using multiple sign-in), which can help you avoid problems that occur if your app logs in the wrong user account. The value can be either an email address or the sub string, which is equivalent to the user's Google+ ID.
 
+* `include_granted_scopes`: If this is provided with the value true, and the authorization request is granted, the authorization will include any previous authorizations granted to this user/application combination for other scopes. See Google's [Incremental Autorization](https://developers.google.com/accounts/docs/OAuth2WebServer#incrementalAuth) for additional details.
+
 Here's an example of a possible configuration where the strategy name is changed, the user is asked for extra permissions, the user is always prompted to select his account when logging in and the user's profile picture is returned as a thumbnail:
 
 ```ruby

--- a/lib/omniauth/strategies/google_oauth2.rb
+++ b/lib/omniauth/strategies/google_oauth2.rb
@@ -10,7 +10,7 @@ module OmniAuth
 
       option :skip_friends, true
 
-      option :authorize_options, [:access_type, :hd, :login_hint, :prompt, :request_visible_actions, :scope, :state, :redirect_uri]
+      option :authorize_options, [:access_type, :hd, :login_hint, :prompt, :request_visible_actions, :scope, :state, :redirect_uri, :include_granted_scopes]
 
       option :client_options, {
         :site          => 'https://accounts.google.com',

--- a/spec/omniauth/strategies/google_oauth2_spec.rb
+++ b/spec/omniauth/strategies/google_oauth2_spec.rb
@@ -132,6 +132,17 @@ describe OmniAuth::Strategies::GoogleOauth2 do
       end
     end
 
+    describe 'include_granted_scopes' do
+      it 'should default to nil' do
+        subject.authorize_params['include_granted_scopes'].should eq(nil)
+      end
+
+      it 'should set the include_granted_scopes parameter if present' do
+        @options = {:include_granted_scopes => 'true'}
+        subject.authorize_params['include_granted_scopes'].should eq('true')
+      end
+    end
+
     describe 'scope' do
       it 'should expand scope shortcuts' do
         @options = {:scope => 'userinfo.email'}


### PR DESCRIPTION
for authorizations. Meaning of the parameter described here by Google:

https://developers.google.com/accounts/docs/OAuth2WebServer#formingtheurl and https://developers.google.com/accounts/docs/OAuth2WebServer#incrementalAuth
