### PR TITLE
Add openid to default scope

### DIFF
--- a/lib/omniauth/strategies/google_oauth2.rb
+++ b/lib/omniauth/strategies/google_oauth2.rb
@@ -4,7 +4,7 @@ module OmniAuth
   module Strategies
     class GoogleOauth2 < OmniAuth::Strategies::OAuth2
       BASE_SCOPE_URL = "https://www.googleapis.com/auth/"
-      DEFAULT_SCOPE = "profile,email"
+      DEFAULT_SCOPE = "openid,profile,email"
       LEAVE_SCOPES_AS_IS = %w(openid profile email)
 
       option :name, 'google_oauth2'
@@ -35,7 +35,7 @@ module OmniAuth
         end
       end
 
-      uid { raw_info['id'] || verified_email }
+      uid { raw_info['sub'] || verified_email }
 
       info do
         prune!({
@@ -59,7 +59,7 @@ module OmniAuth
       end
 
       def raw_info
-        @raw_info ||= access_token.get('https://www.googleapis.com/plus/v1/people/me').parsed
+        @raw_info ||= access_token.get('https://www.googleapis.com/plus/v1/people/me/openIdConnect').parsed
       end
 
       def raw_friend_info(id)
@@ -86,7 +86,7 @@ module OmniAuth
       end
 
       def verified_email
-        raw_info['verified_email'] ? raw_info['email'] : nil
+        raw_info['email_verified'] ? raw_info['email'] : nil
       end
 
       def image_url(options)

--- a/spec/omniauth/strategies/google_oauth2_spec.rb
+++ b/spec/omniauth/strategies/google_oauth2_spec.rb
@@ -159,8 +159,8 @@ describe OmniAuth::Strategies::GoogleOauth2 do
         subject.authorize_params['scope'].should eq('profile email')
       end
 
-      it 'should set default scope to profile,email' do
-        subject.authorize_params['scope'].should eq('profile email')
+      it 'should set default scope to openid,profile,email' do
+        subject.authorize_params['scope'].should eq('openid profile email')
       end
 
       it 'should support space delimited scopes' do
@@ -260,7 +260,7 @@ describe OmniAuth::Strategies::GoogleOauth2 do
       OAuth2::Client.new('abc', 'def') do |builder|
         builder.request :url_encoded
         builder.adapter :test do |stub|
-          stub.get('/plus/v1/people/me') {|env| [200, {'content-type' => 'application/json'}, '{"id": "12345"}']}
+          stub.get('/plus/v1/people/me/openIdConnect') {|env| [200, {'content-type' => 'application/json'}, '{"id": "12345"}']}
           stub.get('/plus/v1/people/12345/people/visible') {|env| [200, {'content-type' => 'application/json'}, '[{"foo":"bar"}]']}
         end
       end


### PR DESCRIPTION
For getting a user's profile like the userinfo endpoint,  the openid is needed for OpenID Connect.

But the user's profile depends on the scope, we might have to cover all patterns.
