### PR TITLE
Update rspec version and run transpec, to switch to RSpec 3.x syntax

### DIFF
--- a/omniauth-contrib.gemspec
+++ b/omniauth-contrib.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency 'omniauth-oauth2'
 
-  gem.add_development_dependency 'rspec', '~> 2.6.0'
+  gem.add_development_dependency 'rspec', '>= 2.14.0'
   gem.add_development_dependency 'rake'
 end

--- a/spec/omniauth/strategies/google_oauth2_spec.rb
+++ b/spec/omniauth/strategies/google_oauth2_spec.rb
@@ -11,7 +11,7 @@ describe OmniAuth::Strategies::GoogleOauth2 do
 
   subject do
     OmniAuth::Strategies::GoogleOauth2.new(app, 'appid', 'secret', @options || {}).tap do |strategy|
-      strategy.stub(:request) {
+      allow(strategy).to receive(:request) {
         request
       }
     end
@@ -27,31 +27,31 @@ describe OmniAuth::Strategies::GoogleOauth2 do
 
   describe '#client_options' do
     it 'has correct site' do
-      subject.client.site.should eq('https://accounts.google.com')
+      expect(subject.client.site).to eq('https://accounts.google.com')
     end
 
     it 'has correct authorize_url' do
-      subject.client.options[:authorize_url].should eq('/o/oauth2/auth')
+      expect(subject.client.options[:authorize_url]).to eq('/o/oauth2/auth')
     end
 
     it 'has correct token_url' do
-      subject.client.options[:token_url].should eq('/o/oauth2/token')
+      expect(subject.client.options[:token_url]).to eq('/o/oauth2/token')
     end
 
     describe "overrides" do
       it 'should allow overriding the site' do
         @options = {:client_options => {'site' => 'https://example.com'}}
-        subject.client.site.should == 'https://example.com'
+        expect(subject.client.site).to eq('https://example.com')
       end
 
       it 'should allow overriding the authorize_url' do
         @options = {:client_options => {'authorize_url' => 'https://example.com'}}
-        subject.client.options[:authorize_url].should == 'https://example.com'
+        expect(subject.client.options[:authorize_url]).to eq('https://example.com')
       end
 
       it 'should allow overriding the token_url' do
         @options = {:client_options => {'token_url' => 'https://example.com'}}
-        subject.client.options[:token_url].should == 'https://example.com'
+        expect(subject.client.options[:token_url]).to eq('https://example.com')
       end
     end
   end
@@ -60,146 +60,146 @@ describe OmniAuth::Strategies::GoogleOauth2 do
     [:access_type, :hd, :login_hint, :prompt, :scope, :state].each do |k|
       it "should support #{k}" do
         @options = {k => 'http://someval'}
-        subject.authorize_params[k.to_s].should eq('http://someval')
+        expect(subject.authorize_params[k.to_s]).to eq('http://someval')
       end
     end
 
     describe "redirect_uri" do
       it 'should default to nil' do
         @options = {}
-        subject.authorize_params['redirect_uri'].should eq(nil)
+        expect(subject.authorize_params['redirect_uri']).to eq(nil)
       end
 
       it 'should set the redirect_uri parameter if present' do
         @options = {:redirect_uri => 'https://example.com'}
-        subject.authorize_params['redirect_uri'].should eq('https://example.com')
+        expect(subject.authorize_params['redirect_uri']).to eq('https://example.com')
       end
     end
 
     describe 'access_type' do
       it 'should default to "offline"' do
         @options = {}
-        subject.authorize_params['access_type'].should eq('offline')
+        expect(subject.authorize_params['access_type']).to eq('offline')
       end
 
       it 'should set the access_type parameter if present' do
         @options = {:access_type => 'online'}
-        subject.authorize_params['access_type'].should eq('online')
+        expect(subject.authorize_params['access_type']).to eq('online')
       end
     end
 
     describe 'hd' do
       it "should default to nil" do
-        subject.authorize_params['hd'].should eq(nil)
+        expect(subject.authorize_params['hd']).to eq(nil)
       end
 
       it 'should set the hd (hosted domain) parameter if present' do
         @options = {:hd => 'example.com'}
-        subject.authorize_params['hd'].should eq('example.com')
+        expect(subject.authorize_params['hd']).to eq('example.com')
       end
     end
 
     describe 'login_hint' do
       it "should default to nil" do
-        subject.authorize_params['login_hint'].should eq(nil)
+        expect(subject.authorize_params['login_hint']).to eq(nil)
       end
 
       it 'should set the login_hint parameter if present' do
         @options = {:login_hint => 'john@example.com'}
-        subject.authorize_params['login_hint'].should eq('john@example.com')
+        expect(subject.authorize_params['login_hint']).to eq('john@example.com')
       end
     end
 
     describe 'prompt' do
       it "should default to nil" do
-        subject.authorize_params['prompt'].should eq(nil)
+        expect(subject.authorize_params['prompt']).to eq(nil)
       end
 
       it 'should set the prompt parameter if present' do
         @options = {:prompt => 'consent select_account'}
-        subject.authorize_params['prompt'].should eq('consent select_account')
+        expect(subject.authorize_params['prompt']).to eq('consent select_account')
       end
     end
 
     describe 'request_visible_actions' do
       it "should default to nil" do
-        subject.authorize_params['request_visible_actions'].should eq(nil)
+        expect(subject.authorize_params['request_visible_actions']).to eq(nil)
       end
 
       it 'should set the request_visible_actions parameter if present' do
         @options = {:request_visible_actions => 'something'}
-        subject.authorize_params['request_visible_actions'].should eq('something')
+        expect(subject.authorize_params['request_visible_actions']).to eq('something')
       end
     end
 
     describe 'include_granted_scopes' do
       it 'should default to nil' do
-        subject.authorize_params['include_granted_scopes'].should eq(nil)
+        expect(subject.authorize_params['include_granted_scopes']).to eq(nil)
       end
 
       it 'should set the include_granted_scopes parameter if present' do
         @options = {:include_granted_scopes => 'true'}
-        subject.authorize_params['include_granted_scopes'].should eq('true')
+        expect(subject.authorize_params['include_granted_scopes']).to eq('true')
       end
     end
 
     describe 'scope' do
       it 'should expand scope shortcuts' do
         @options = {:scope => 'userinfo.email'}
-        subject.authorize_params['scope'].should eq('https://www.googleapis.com/auth/userinfo.email')
+        expect(subject.authorize_params['scope']).to eq('https://www.googleapis.com/auth/userinfo.email')
       end
 
       it 'should leave full scopes as is' do
         @options = {:scope => 'https://www.googleapis.com/auth/userinfo.profile'}
-        subject.authorize_params['scope'].should eq('https://www.googleapis.com/auth/userinfo.profile')
+        expect(subject.authorize_params['scope']).to eq('https://www.googleapis.com/auth/userinfo.profile')
       end
 
       it 'should join scopes' do
         @options = {:scope => 'userinfo.profile,userinfo.email'}
-        subject.authorize_params['scope'].should eq('https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/userinfo.email')
+        expect(subject.authorize_params['scope']).to eq('https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/userinfo.email')
       end
 
       it 'should deal with whitespace when joining scopes' do
         @options = {:scope => 'userinfo.profile, userinfo.email'}
-        subject.authorize_params['scope'].should eq('https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/userinfo.email')
+        expect(subject.authorize_params['scope']).to eq('https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/userinfo.email')
       end
 
       it 'should set default scope to userinfo.email,userinfo.profile' do
-        subject.authorize_params['scope'].should eq('https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile')
+        expect(subject.authorize_params['scope']).to eq('https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile')
       end
 
       it 'should support space delimited scopes' do
         @options = {:scope => 'userinfo.profile userinfo.email'}
-        subject.authorize_params['scope'].should eq('https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/userinfo.email')
+        expect(subject.authorize_params['scope']).to eq('https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/userinfo.email')
       end
 
       it "should support extremely badly formed scopes" do
         @options = {:scope => 'userinfo.profile userinfo.email,foo,steve yeah http://example.com'}
-        subject.authorize_params['scope'].should eq('https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/foo https://www.googleapis.com/auth/steve https://www.googleapis.com/auth/yeah http://example.com')
+        expect(subject.authorize_params['scope']).to eq('https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/foo https://www.googleapis.com/auth/steve https://www.googleapis.com/auth/yeah http://example.com')
       end
     end
 
     describe 'state' do
       it 'should set the state parameter' do
         @options = {:state => 'some_state'}
-        subject.authorize_params['state'].should eq('some_state')
-        subject.session['omniauth.state'].should eq('some_state')
+        expect(subject.authorize_params['state']).to eq('some_state')
+        expect(subject.session['omniauth.state']).to eq('some_state')
       end
 
       it 'should set the omniauth.state dynamically' do
-        subject.stub(:request) { double('Request', {:params => {'state' => 'some_state'}, :env => {}}) }
-        subject.authorize_params['state'].should eq('some_state')
-        subject.session['omniauth.state'].should eq('some_state')
+        allow(subject).to receive(:request) { double('Request', {:params => {'state' => 'some_state'}, :env => {}}) }
+        expect(subject.authorize_params['state']).to eq('some_state')
+        expect(subject.session['omniauth.state']).to eq('some_state')
       end
     end
 
     describe "overrides" do
       it 'should include top-level options that are marked as :authorize_options' do
         @options = {:authorize_options => [:scope, :foo, :request_visible_actions], :scope => 'http://bar', :foo => 'baz', :hd => "wow", :request_visible_actions => "something"}
-        subject.authorize_params['scope'].should eq('http://bar')
-        subject.authorize_params['foo'].should eq('baz')
-        subject.authorize_params['hd'].should eq(nil)
-        subject.authorize_params['request_visible_actions'].should eq('something')
+        expect(subject.authorize_params['scope']).to eq('http://bar')
+        expect(subject.authorize_params['foo']).to eq('baz')
+        expect(subject.authorize_params['hd']).to eq(nil)
+        expect(subject.authorize_params['request_visible_actions']).to eq('something')
       end
 
       describe "request overrides" do
@@ -209,7 +209,7 @@ describe OmniAuth::Strategies::GoogleOauth2 do
 
             it "should set the #{k} authorize option dynamically in the request" do
               @options = {k => ''}
-              subject.authorize_params[k.to_s].should eq('http://example.com')
+              expect(subject.authorize_params[k.to_s]).to eq('http://example.com')
             end
           end
         end
@@ -219,7 +219,7 @@ describe OmniAuth::Strategies::GoogleOauth2 do
 
           it "should support request overrides from custom authorize_options" do
             @options = {:authorize_options => [:foo], :foo => ''}
-            subject.authorize_params['foo'].should eq('something')
+            expect(subject.authorize_params['foo']).to eq('something')
           end
         end
       end
@@ -229,34 +229,34 @@ describe OmniAuth::Strategies::GoogleOauth2 do
   describe '#authorize_params' do
     it 'should include any authorize params passed in the :authorize_params option' do
       @options = {:authorize_params => {:request_visible_actions => 'something', :foo => 'bar', :baz => 'zip'}, :hd => 'wow', :bad => 'not_included'}
-      subject.authorize_params['request_visible_actions'].should eq('something')
-      subject.authorize_params['foo'].should eq('bar')
-      subject.authorize_params['baz'].should eq('zip')
-      subject.authorize_params['hd'].should eq('wow')
-      subject.authorize_params['bad'].should eq(nil)
+      expect(subject.authorize_params['request_visible_actions']).to eq('something')
+      expect(subject.authorize_params['foo']).to eq('bar')
+      expect(subject.authorize_params['baz']).to eq('zip')
+      expect(subject.authorize_params['hd']).to eq('wow')
+      expect(subject.authorize_params['bad']).to eq(nil)
     end
   end
 
   describe '#token_params' do
     it 'should include any token params passed in the :token_params option' do
       @options = {:token_params => {:foo => 'bar', :baz => 'zip'}}
-      subject.token_params['foo'].should eq('bar')
-      subject.token_params['baz'].should eq('zip')
+      expect(subject.token_params['foo']).to eq('bar')
+      expect(subject.token_params['baz']).to eq('zip')
     end
   end
 
   describe "#token_options" do
     it 'should include top-level options that are marked as :token_options' do
       @options = {:token_options => [:scope, :foo], :scope => 'bar', :foo => 'baz', :bad => 'not_included'}
-      subject.token_params['scope'].should eq('bar')
-      subject.token_params['foo'].should eq('baz')
-      subject.token_params['bad'].should eq(nil)
+      expect(subject.token_params['scope']).to eq('bar')
+      expect(subject.token_params['foo']).to eq('baz')
+      expect(subject.token_params['bad']).to eq(nil)
     end
   end
 
   describe '#callback_path' do
     it 'has the correct callback path' do
-      subject.callback_path.should eq('/auth/google_oauth2/callback')
+      expect(subject.callback_path).to eq('/auth/google_oauth2/callback')
     end
   end
 
@@ -279,13 +279,13 @@ describe OmniAuth::Strategies::GoogleOauth2 do
        let(:access_token) { OAuth2::AccessToken.from_hash(client, {'id_token' => 'xyz'}) }
 
         it 'should include id_token when set on the access_token' do
-          subject.extra.should include(:id_token => 'xyz')
+          expect(subject.extra).to include(:id_token => 'xyz')
         end
       end
 
       context 'when the id_token is missing' do
         it 'should not include id_token' do
-          subject.extra.should_not have_key(:id_token)
+          expect(subject.extra).not_to have_key(:id_token)
         end
       end
     end
@@ -295,7 +295,7 @@ describe OmniAuth::Strategies::GoogleOauth2 do
         before { subject.options[:skip_info] = true }
 
         it 'should not include raw_info' do
-          subject.extra.should_not have_key(:raw_info)
+          expect(subject.extra).not_to have_key(:raw_info)
         end
       end
 
@@ -303,7 +303,7 @@ describe OmniAuth::Strategies::GoogleOauth2 do
         before { subject.options[:skip_info] = false }
 
         it 'should include raw_info' do
-          subject.extra[:raw_info].should eq('id' => '12345')
+          expect(subject.extra[:raw_info]).to eq('id' => '12345')
         end
       end
     end
@@ -313,7 +313,7 @@ describe OmniAuth::Strategies::GoogleOauth2 do
         before { subject.options[:skip_info] = true }
 
         it 'should not include raw_friend_info' do
-          subject.extra.should_not have_key(:raw_friend_info)
+          expect(subject.extra).not_to have_key(:raw_friend_info)
         end
       end
 
@@ -324,7 +324,7 @@ describe OmniAuth::Strategies::GoogleOauth2 do
           before { subject.options[:skip_friends] = true }
 
           it 'should not include raw_friend_info' do
-            subject.extra.should_not have_key(:raw_friend_info)
+            expect(subject.extra).not_to have_key(:raw_friend_info)
           end
         end
 
@@ -332,7 +332,7 @@ describe OmniAuth::Strategies::GoogleOauth2 do
           before { subject.options[:skip_friends] = false }
 
           it 'should not include raw_friend_info' do
-            subject.extra[:raw_friend_info].should eq([{'foo' => 'bar'}])
+            expect(subject.extra[:raw_friend_info]).to eq([{'foo' => 'bar'}])
           end
         end
       end
@@ -341,92 +341,92 @@ describe OmniAuth::Strategies::GoogleOauth2 do
 
   describe 'populate auth hash urls' do
     it 'should populate url map in auth hash if link present in raw_info' do
-      subject.stub(:raw_info) { {'name' => 'Foo', 'link' => 'https://plus.google.com/123456'} }
-      subject.info[:urls]['Google'].should eq('https://plus.google.com/123456')
+      allow(subject).to receive(:raw_info) { {'name' => 'Foo', 'link' => 'https://plus.google.com/123456'} }
+      expect(subject.info[:urls]['Google']).to eq('https://plus.google.com/123456')
     end
 
     it 'should not populate url map in auth hash if no link present in raw_info' do
-      subject.stub(:raw_info) { {'name' => 'Foo'} }
-      subject.info.should_not have_key(:urls)
+      allow(subject).to receive(:raw_info) { {'name' => 'Foo'} }
+      expect(subject.info).not_to have_key(:urls)
     end
   end
 
   describe 'image options' do
     it "should have no image if a picture isn't present" do
       @options = {:image_aspect_ratio => 'square'}
-      subject.stub(:raw_info) { {'name' => 'User Without Pic'} }
-      subject.info[:image].should be_nil
+      allow(subject).to receive(:raw_info) { {'name' => 'User Without Pic'} }
+      expect(subject.info[:image]).to be_nil
     end
 
     describe "when a picture is returned from google" do
       it 'should return the image with size specified in the `image_size` option' do
         @options = {:image_size => 50}
-        subject.stub(:raw_info) { {'picture' => 'https://lh3.googleusercontent.com/url/photo.jpg'} }
-        subject.info[:image].should eq('https://lh3.googleusercontent.com/url/s50/photo.jpg')
+        allow(subject).to receive(:raw_info) { {'picture' => 'https://lh3.googleusercontent.com/url/photo.jpg'} }
+        expect(subject.info[:image]).to eq('https://lh3.googleusercontent.com/url/s50/photo.jpg')
       end
 
       it 'should return the image with width and height specified in the `image_size` option' do
         @options = {:image_size => {:width => 50, :height => 40}}
-        subject.stub(:raw_info) { {'picture' => 'https://lh3.googleusercontent.com/url/photo.jpg'} }
-        subject.info[:image].should eq('https://lh3.googleusercontent.com/url/w50-h40/photo.jpg')
+        allow(subject).to receive(:raw_info) { {'picture' => 'https://lh3.googleusercontent.com/url/photo.jpg'} }
+        expect(subject.info[:image]).to eq('https://lh3.googleusercontent.com/url/w50-h40/photo.jpg')
       end
 
       it 'should return square image when `image_aspect_ratio` is specified' do
         @options = {:image_aspect_ratio => 'square'}
-        subject.stub(:raw_info) { {'picture' => 'https://lh3.googleusercontent.com/url/photo.jpg'} }
-        subject.info[:image].should eq('https://lh3.googleusercontent.com/url/c/photo.jpg')
+        allow(subject).to receive(:raw_info) { {'picture' => 'https://lh3.googleusercontent.com/url/photo.jpg'} }
+        expect(subject.info[:image]).to eq('https://lh3.googleusercontent.com/url/c/photo.jpg')
       end
 
       it 'should return square sized image when `image_aspect_ratio` and `image_size` is set' do
         @options = {:image_aspect_ratio => 'square', :image_size => 50}
-        subject.stub(:raw_info) { {'picture' => 'https://lh3.googleusercontent.com/url/photo.jpg'} }
-        subject.info[:image].should eq('https://lh3.googleusercontent.com/url/s50-c/photo.jpg')
+        allow(subject).to receive(:raw_info) { {'picture' => 'https://lh3.googleusercontent.com/url/photo.jpg'} }
+        expect(subject.info[:image]).to eq('https://lh3.googleusercontent.com/url/s50-c/photo.jpg')
       end
 
       it 'should return square sized image when `image_aspect_ratio` and `image_size` has height and width' do
         @options = {:image_aspect_ratio => 'square', :image_size => {:width => 50, :height => 40}}
-        subject.stub(:raw_info) { {'picture' => 'https://lh3.googleusercontent.com/url/photo.jpg'} }
-        subject.info[:image].should eq('https://lh3.googleusercontent.com/url/w50-h40-c/photo.jpg')
+        allow(subject).to receive(:raw_info) { {'picture' => 'https://lh3.googleusercontent.com/url/photo.jpg'} }
+        expect(subject.info[:image]).to eq('https://lh3.googleusercontent.com/url/w50-h40-c/photo.jpg')
       end
     end
 
     it 'should return original image if no options are provided' do
-      subject.stub(:raw_info) { {'picture' => 'https://lh3.googleusercontent.com/url/photo.jpg'} }
-      subject.info[:image].should eq('https://lh3.googleusercontent.com/url/photo.jpg')
+      allow(subject).to receive(:raw_info) { {'picture' => 'https://lh3.googleusercontent.com/url/photo.jpg'} }
+      expect(subject.info[:image]).to eq('https://lh3.googleusercontent.com/url/photo.jpg')
     end
   end
 
   describe 'build_access_token' do
     it 'should use a hybrid authorization request_uri if this is an AJAX request with a code parameter' do
-      request.stub(:xhr?).and_return(true)
-      request.stub(:params).and_return('code' => 'valid_code')
+      allow(request).to receive(:xhr?).and_return(true)
+      allow(request).to receive(:params).and_return('code' => 'valid_code')
 
       client = double(:client)
       auth_code = double(:auth_code)
-      client.stub(:auth_code).and_return(auth_code)
-      subject.should_receive(:client).and_return(client)
-      auth_code.should_receive(:get_token).with('valid_code', { :redirect_uri => 'postmessage'}, {})
+      allow(client).to receive(:auth_code).and_return(auth_code)
+      expect(subject).to receive(:client).and_return(client)
+      expect(auth_code).to receive(:get_token).with('valid_code', { :redirect_uri => 'postmessage'}, {})
 
-      subject.should_not_receive(:orig_build_access_token)
+      expect(subject).not_to receive(:orig_build_access_token)
       subject.build_access_token
     end
 
     it 'should read access_token from hash if this is not an AJAX request with a code parameter' do
-      request.stub(:xhr?).and_return(false)
-      request.stub(:params).and_return('id_token' => 'valid_id_token', 'access_token' => 'valid_access_token')
-      subject.should_receive(:verify_token).with('valid_id_token', 'valid_access_token').and_return true
-      subject.should_receive(:client).and_return(:client)
+      allow(request).to receive(:xhr?).and_return(false)
+      allow(request).to receive(:params).and_return('id_token' => 'valid_id_token', 'access_token' => 'valid_access_token')
+      expect(subject).to receive(:verify_token).with('valid_id_token', 'valid_access_token').and_return true
+      expect(subject).to receive(:client).and_return(:client)
 
       token = subject.build_access_token
-      token.should be_instance_of(::OAuth2::AccessToken)
-      token.token.should eq('valid_access_token')
-      token.client.should eq(:client)
+      expect(token).to be_instance_of(::OAuth2::AccessToken)
+      expect(token.token).to eq('valid_access_token')
+      expect(token.client).to eq(:client)
     end
 
     it 'should call super if this is not an AJAX request' do
-      request.stub(:xhr?).and_return(false)
-      request.stub(:params).and_return('code' => 'valid_code')
-      subject.should_receive(:orig_build_access_token)
+      allow(request).to receive(:xhr?).and_return(false)
+      allow(request).to receive(:params).and_return('code' => 'valid_code')
+      expect(subject).to receive(:orig_build_access_token)
       subject.build_access_token
     end
   end
@@ -457,11 +457,11 @@ describe OmniAuth::Strategies::GoogleOauth2 do
 
     it 'should verify token if access_token and id_token are valid and app_id equals' do
       subject.options.client_id = '000000000000.apps.googleusercontent.com'
-      subject.send(:verify_token, 'valid_id_token', 'valid_access_token').should == true
+      expect(subject.send(:verify_token, 'valid_id_token', 'valid_access_token')).to eq(true)
     end
 
     it 'should not verify token if access_token and id_token are valid but app_id is false' do
-      subject.send(:verify_token, 'valid_id_token', 'valid_access_token').should == false
+      expect(subject.send(:verify_token, 'valid_id_token', 'valid_access_token')).to eq(false)
     end
 
     it 'should raise error if access_token or id_token is invalid' do


### PR DESCRIPTION
1. Updated development dependency to RSpec 2.14.0 and up
2. Ran transpec to convert spec files to newer syntax
