### PR TITLE
call constants on self to make extending the class easier

### DIFF
--- a/lib/omniauth/strategies/google_oauth2.rb
+++ b/lib/omniauth/strategies/google_oauth2.rb
@@ -25,9 +25,9 @@ module OmniAuth
             params[k] = request.params[k.to_s] unless [nil, ''].include?(request.params[k.to_s])
           end
 
-          raw_scope = params[:scope] || DEFAULT_SCOPE
+          raw_scope = params[:scope] || self.class::DEFAULT_SCOPE
           scope_list = raw_scope.split(" ").map {|item| item.split(",")}.flatten
-          scope_list.map! { |s| s =~ /^https?:\/\// || BASE_SCOPES.include?(s) ? s : "#{BASE_SCOPE_URL}#{s}" }
+          scope_list.map! { |s| s =~ /^https?:\/\// || self.class::BASE_SCOPES.include?(s) ? s : "#{self.class::BASE_SCOPE_URL}#{s}" }
           params[:scope] = scope_list.join(" ")
           params[:access_type] = 'offline' if params[:access_type].nil?
 

--- a/spec/omniauth/strategies/google_oauth2_spec.rb
+++ b/spec/omniauth/strategies/google_oauth2_spec.rb
@@ -202,6 +202,18 @@ describe OmniAuth::Strategies::GoogleOauth2 do
         expect(subject.authorize_params['request_visible_actions']).to eq('something')
       end
 
+      it 'should get the default scope from the current class to allow class extensions' do
+        class OmniAuth::Strategies::Foo < OmniAuth::Strategies::GoogleOauth2
+          DEFAULT_SCOPE = 'http://bar'
+        end
+        foo = OmniAuth::Strategies::Foo.new(app, 'appid', 'secret', {}).tap do |strategy|
+          allow(strategy).to receive(:request) {
+            request
+          }
+        end
+        expect(foo.authorize_params['scope']).to eq('http://bar')
+      end
+
       describe "request overrides" do
         [:access_type, :hd, :login_hint, :prompt, :scope, :state].each do |k|
           context "authorize option #{k}" do


### PR DESCRIPTION
I've made a minor change that makes extending the strategy easier.

I'm working on an app where we wanted to split up Google/YouTube authentication and tried solving that by creating strategies like:

```
class OmniAuth::Strategies::Youtube < OmniAuth::Strategies::GoogleOauth2
  DEFAULT_SCOPE = 'userinfo.email,youtube'
  option :name, 'youtube'
end
```

This doesn't work though, when going through the `authorize_params` method the strategy used GoogleOauth2's DEFAULT_SCOPE. This PR fixes that problem (while keeping the old behaviour intact for other users).

I've added a spec that proves the change is working, however I could use some help cleaning up the spec. There should be an easier (and more readable) way to prove that the change is working.
