### PR TITLE
Convert specs to RSpec 2.14.8 syntax with Transpec

### DIFF
--- a/spec/omniauth/strategies/google_oauth2_spec.rb
+++ b/spec/omniauth/strategies/google_oauth2_spec.rb
@@ -391,8 +391,8 @@ describe OmniAuth::Strategies::GoogleOauth2 do
 
       it 'should return original image if image url does not end in `photo.jpg`' do
         @options = {:image_size => 50}
-        subject.stub(:raw_info) { {'picture' => 'https://lh3.googleusercontent.com/url/photograph.jpg'} }
-        subject.info[:image].should eq('https://lh3.googleusercontent.com/url/photograph.jpg')
+        allow(subject).to receive(:raw_info) { {'picture' => 'https://lh3.googleusercontent.com/url/photograph.jpg'} }
+        expect(subject.info[:image]).to eq('https://lh3.googleusercontent.com/url/photograph.jpg')
       end
     end
 


### PR DESCRIPTION
This conversion is done by Transpec 1.10.4 with the following command:
    transpec
- 1 conversion
  from: obj.stub(:message)
    to: allow(obj).to receive(:message)
- 1 conversion
  from: obj.should
    to: expect(obj).to
