### PR TITLE
add step to fix 'Error: invalid_client no application name'

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Then `bundle install`.
 * Select your project.
 * Click 'APIs & auth'
 * Make sure "Contacts API" and "Google+ API" are on.
+* Go to Consent Screen, and provide a 'PRODUCT NAME'
 * Wait 10 minutes for changes to take effect.
 
 ## Usage


### PR DESCRIPTION
This has been discussed in SO, and I also confirm that this works.

After I set a product name, the `Error: invalid_client` goes away, and continued to prompt to allow access.
