### PR TITLE
Create CHANGELOG and clearly document API deprecation in 0.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ All notable changes to this project will be documented in this file.
 - Now requiring the "Contacts API" and "Google+ API" to be enabled in your Google API console.
 
 ### Deprecated
-- Support for the old Google OAuth API. `OAuth2::Error` will be thrown and state that access is not configured when you attempt to authenticate using the old API. See Added section for this release.
+- The old Google OAuth API support was removed without deprecation.
 
 ### Removed
-- Nothing.
+- Support for the old Google OAuth API. `OAuth2::Error` will be thrown and state that access is not configured when you attempt to authenticate using the old API. See Added section for this release.
 
 ### Fixed
 - Nothing.


### PR DESCRIPTION
See https://github.com/zquestz/omniauth-google-oauth2/issues/111#issuecomment-44718385.
