### PR TITLE
Updated prompt to approval_prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,12 +50,11 @@ You can configure several options, which you pass in to the `provider` method vi
 * `scope`: A comma-separated list of permissions you want to request from the user. See the [Google OAuth 2.0 Playground](https://developers.google.com/oauthplayground/) for a full list of available permissions. Caveats:
   * The `email` and `profile` scopes are used by default. By defining your own `scope`, you override these defaults. If you need these scopes, don't forget to add them yourself!
   * Scopes starting with `https://www.googleapis.com/auth/` do not need that prefix specified. So while you can use the smaller scope `books` since that permission starts with the mentioned prefix, you should use the full scope URL `https://docs.google.com/feeds/` to access a user's docs, for example.
-* `prompt`: A space-delimited list of string values that determines whether the user is re-prompted for authentication and/or consent. Possible values are:
-  * `none`: No authentication or consent pages will be displayed; it will return an error if the user is not already authenticated and has not pre-configured consent for the requested scopes. This can be used as a method to check for existing authentication and/or consent.
-  * `consent`: The user will always be prompted for consent, even if he has previously allowed access a given set of scopes.
-  * `select_account`: The user will always be prompted to select a user account. This allows a user who has multiple current account sessions to select one amongst them.
+* `approval_prompt`: Indicates whether the user should be re-prompted for consent. Possible values are:
+  * `auto`: User should only see the consent page for a given set of scopes the first time through the sequence.
+  * `force`: User sees a consent page even if they previously gave consent to your application for a given set of scopes.
 
-  If no value is specified, the user only sees the authentication page if he is not logged in and only sees the consent page the first time he authorizes a given set of scopes.
+  Defaults to `auto`.
 
 * `image_aspect_ratio`: The shape of the user's profile picture. Possible values are:
   * `original`: Picture maintains its original aspect ratio.

--- a/lib/omniauth/strategies/google_oauth2.rb
+++ b/lib/omniauth/strategies/google_oauth2.rb
@@ -11,7 +11,7 @@ module OmniAuth
 
       option :skip_friends, true
 
-      option :authorize_options, [:access_type, :hd, :login_hint, :prompt, :request_visible_actions, :scope, :state, :redirect_uri, :include_granted_scopes]
+      option :authorize_options, [:access_type, :hd, :login_hint, :approval_prompt, :request_visible_actions, :scope, :state, :redirect_uri, :include_granted_scopes]
 
       option :client_options, {
         :site          => 'https://accounts.google.com',

--- a/spec/omniauth/strategies/google_oauth2_spec.rb
+++ b/spec/omniauth/strategies/google_oauth2_spec.rb
@@ -57,7 +57,7 @@ describe OmniAuth::Strategies::GoogleOauth2 do
   end
 
   describe "#authorize_options" do
-    [:access_type, :hd, :login_hint, :prompt, :scope, :state].each do |k|
+    [:access_type, :hd, :login_hint, :approval_prompt, :scope, :state].each do |k|
       it "should support #{k}" do
         @options = {k => 'http://someval'}
         expect(subject.authorize_params[k.to_s]).to eq('http://someval')
@@ -110,14 +110,14 @@ describe OmniAuth::Strategies::GoogleOauth2 do
       end
     end
 
-    describe 'prompt' do
+    describe 'approval_prompt' do
       it "should default to nil" do
-        expect(subject.authorize_params['prompt']).to eq(nil)
+        expect(subject.authorize_params['approval_prompt']).to eq(nil)
       end
 
-      it 'should set the prompt parameter if present' do
-        @options = {:prompt => 'consent select_account'}
-        expect(subject.authorize_params['prompt']).to eq('consent select_account')
+      it 'should set the approval_prompt parameter if present' do
+        @options = {:approval_prompt => 'force'}
+        expect(subject.authorize_params['approval_prompt']).to eq('force')
       end
     end
 
@@ -203,7 +203,7 @@ describe OmniAuth::Strategies::GoogleOauth2 do
       end
 
       describe "request overrides" do
-        [:access_type, :hd, :login_hint, :prompt, :scope, :state].each do |k|
+        [:access_type, :hd, :login_hint, :approval_prompt, :scope, :state].each do |k|
           context "authorize option #{k}" do
             let(:request) { double('Request', :params => {k.to_s => 'http://example.com'}, :cookies => {}, :env => {}) }
 
@@ -400,7 +400,7 @@ describe OmniAuth::Strategies::GoogleOauth2 do
       allow(subject).to receive(:raw_info) { {'picture' => 'https://lh3.googleusercontent.com/url/photo.jpg'} }
       expect(subject.info[:image]).to eq('https://lh3.googleusercontent.com/url/photo.jpg')
     end
-    
+
     it 'should return correct image if google image url has double https' do
       allow(subject).to receive(:raw_info) { {'picture' => 'https:https://lh3.googleusercontent.com/url/photo.jpg'} }
       expect(subject.info[:image]).to eq('https://lh3.googleusercontent.com/url/photo.jpg')


### PR DESCRIPTION
The Google OAuth2 doc shows that developers should use approval_prompt for indicating whether the user should be re-prompted for consent.

https://developers.google.com/accounts/docs/OAuth2WebServer#formingtheurl
