### PR TITLE
Add approval_prompt option into authorize_options

### DIFF
--- a/lib/omniauth/strategies/google_oauth2.rb
+++ b/lib/omniauth/strategies/google_oauth2.rb
@@ -11,7 +11,7 @@ module OmniAuth
 
       option :skip_friends, true
 
-      option :authorize_options, [:access_type, :hd, :login_hint, :prompt, :request_visible_actions, :scope, :state, :redirect_uri, :include_granted_scopes]
+      option :authorize_options, [:access_type, :hd, :login_hint, :prompt, :approval_prompt, :request_visible_actions, :scope, :state, :redirect_uri, :include_granted_scopes]
 
       option :client_options, {
         :site          => 'https://accounts.google.com',


### PR DESCRIPTION
According to [docs](https://developers.google.com/accounts/docs/OAuth2UserAgent)

> approval_prompt | force or auto | Indicates if the user should be re-prompted for consent. The default is auto, so a given user should only see the consent page for a given set of scopes the first time through the sequence. If the value is force, then the user sees a consent page even if they previously gave consent to your application for a given set of scopes.
