### PR TITLE
Use the `People: get` endpoint for `raw_info` hash

### DIFF
--- a/lib/omniauth/strategies/google_oauth2.rb
+++ b/lib/omniauth/strategies/google_oauth2.rb
@@ -58,8 +58,21 @@ module OmniAuth
         prune! hash
       end
 
+      # Mimic people#openIdConnect response
       def raw_info
-        @raw_info ||= access_token.get('https://www.googleapis.com/plus/v1/people/me/openIdConnect').parsed
+        @raw_info ||= Hash.new.tap do |data|
+          raw = access_token.get('https://www.googleapis.com/plus/v1/people/me').parsed
+
+          data['email']          = raw['emails'].first.try(:[], 'value')
+          data['email_verified'] = !!data['email']
+          data['gender']         = raw['gender']
+          data['family_name']    = raw['name'].try(:[], 'familyName')
+          data['given_name']     = raw['name'].try(:[], 'givenName')
+          data['kind']           = raw['kind']
+          data['name']           = raw['displayName']
+          data['profile']        = raw['url']
+          data['picture']        = raw['image'].try(:[], 'url')
+        end
       end
 
       def raw_friend_info(id)


### PR DESCRIPTION
I'm not sure if you're interested in a patch like this—but for some unknown reason google's `people#openIdConnect` was not returning all available information, however other API endpoints were. So this uses the `people#me` endpoint to mimic the response of `people#openIdConnect`.
