### PR TITLE
alias -> alias_method

### DIFF
--- a/lib/omniauth/strategies/google_oauth2.rb
+++ b/lib/omniauth/strategies/google_oauth2.rb
@@ -78,7 +78,7 @@ module OmniAuth
         end
       end
       alias_method :orig_build_access_token, :build_access_token
-      alias :build_access_token :custom_build_access_token
+      alias_method :build_access_token, :custom_build_access_token
 
       private
 


### PR DESCRIPTION
This addresses the closed issue #131 basically alias and alias_method work very differently in terms of scoping you can read more [here](http://blog.bigbinary.com/2012/01/08/alias-vs-alias-method.html) essentially because of this `custom_build_access_token` was never getting called and the Hybrid Authentication flow described in the readme was impossible. Now the `custom_build_access_token` gets called as expected.
