### PR TITLE
Add support for upgrading OpenID logins to OAuth logins

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ You can configure several options, which you pass in to the `provider` method vi
 
 * `include_granted_scopes`: If this is provided with the value true, and the authorization request is granted, the authorization will include any previous authorizations granted to this user/application combination for other scopes. See Google's [Incremental Autorization](https://developers.google.com/accounts/docs/OAuth2WebServer#incrementalAuth) for additional details.
 
+* `openid_realm`: Set the OpenID realm value, to allow upgrading from OpenID based authentication to OAuth 2 based authentication. When this is set correctly an `openid_id` value will be set in `[:extra][:id_info]` in the authentication hash with the value of the user's OpenID ID URL.
+
 Here's an example of a possible configuration where the strategy name is changed, the user is asked for extra permissions, the user is always prompted to select his account when logging in and the user's profile picture is returned as a thumbnail:
 
 ```ruby
@@ -123,6 +125,18 @@ Here's an example of an authentication hash available in the callback by accessi
             :birthday => "0000-06-25",
             :locale => "en",
             :hd => "company_name.com"
+        },
+        :id_info => {
+            "iss" => "accounts.google.com",
+            "at_hash" => "HK6E_P6Dh8Y93mRNtsDB1Q",
+            "email_verified" => "true",
+            "sub" => "10769150350006150715113082367",
+            "azp" => "APP_ID",
+            "email" => "jsmith@example.com",
+            "aud" => "APP_ID",
+            "iat" => 1353601026,
+            "exp" => 1353604926
+            "openid_id" => "https://www.google.com/accounts/o8/id?id=ABCdfdswawerSDFDsfdsfdfjdsf"
         }
     }
 }

--- a/omniauth-google-oauth2.gemspec
+++ b/omniauth-google-oauth2.gemspec
@@ -16,6 +16,8 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency 'omniauth', '>= 1.1.1'
   gem.add_runtime_dependency 'omniauth-oauth2', '>= 1.1.1'
+  gem.add_runtime_dependency 'jwt', '~> 1.0'
+  gem.add_runtime_dependency 'multi_json', '~> 1.3'
 
   gem.add_development_dependency 'rspec', '>= 2.14.0'
   gem.add_development_dependency 'rake'

--- a/spec/omniauth/strategies/google_oauth2_spec.rb
+++ b/spec/omniauth/strategies/google_oauth2_spec.rb
@@ -276,16 +276,25 @@ describe OmniAuth::Strategies::GoogleOauth2 do
 
     describe 'id_token' do
       context 'when the id_token is passed into the access token' do
-       let(:access_token) { OAuth2::AccessToken.from_hash(client, {'id_token' => 'xyz'}) }
+        id_token = JWT.encode({'abc' => 'xyz'}, 'secret')
+        let(:access_token) { OAuth2::AccessToken.from_hash(client, {'id_token' => id_token}) }
 
         it 'should include id_token when set on the access_token' do
-          expect(subject.extra).to include(:id_token => 'xyz')
+          expect(subject.extra).to include(:id_token => id_token)
+        end
+
+        it 'should include id_info when id_token set on the access_token' do
+          expect(subject.extra).to include(:id_info => {'abc' => 'xyz'})
         end
       end
 
       context 'when the id_token is missing' do
         it 'should not include id_token' do
           expect(subject.extra).not_to have_key(:id_token)
+        end
+
+        it 'should not include id_info' do
+          expect(subject.extra).not_to have_key(:id_info)
         end
       end
     end


### PR DESCRIPTION
This allows `openid.realm` to be specified in the request, and adds a copy of the decrypted ID token to the authentication hash so that the callback can access `openid_id` in order to do the upgrade.

It may be that there is a better way to make `openid_id` available than this, but the key thing is that it only seems to be available in the returned ID token, and not in the `/plus/v1/people/me/openIdConnect` response object. Currently the signature on the ID token is not being verified when decoding it, but `custom_build_access_token` has already done so I believe, and Google suggest it's not necessary for a server that has got the token directly from Google:

* https://developers.google.com/accounts/docs/OpenIDConnect#obtainuserinfo
* https://developers.google.com/accounts/docs/OpenIDConnect#validatinganidtoken

There are probably going to be an increasing number of people looking to be able to do this upgrade because OpenID 2.0 support is going away on 20th April (https://developers.google.com/accounts/docs/OpenID#shutdown-timetable).