### PR TITLE
Handle authorization codes coming from an installed applications

### DIFF
--- a/lib/omniauth/strategies/google_oauth2.rb
+++ b/lib/omniauth/strategies/google_oauth2.rb
@@ -69,7 +69,12 @@ module OmniAuth
       def custom_build_access_token
         if request.xhr? && request.params['code']
           verifier = request.params['code']
-          client.auth_code.get_token(verifier, { :redirect_uri => 'postmessage'}.merge(token_params.to_hash(:symbolize_keys => true)),
+          client.auth_code.get_token(verifier, { :redirect_uri => 'postmessage' }.merge(token_params.to_hash(:symbolize_keys => true)),
+                                     deep_symbolize(options.auth_token_params || {}))
+        elsif request.params['code'] && request.params['redirect_uri']
+          verifier = request.params['code']
+          redirect_uri = request.params['redirect_uri']
+          client.auth_code.get_token(verifier, { :redirect_uri => redirect_uri }.merge(token_params.to_hash(:symbolize_keys => true)),
                                      deep_symbolize(options.auth_token_params || {}))
         elsif verify_token(request.params['id_token'], request.params['access_token'])
           ::OAuth2::AccessToken.from_hash(client, request.params.dup)

--- a/spec/omniauth/strategies/google_oauth2_spec.rb
+++ b/spec/omniauth/strategies/google_oauth2_spec.rb
@@ -422,6 +422,20 @@ describe OmniAuth::Strategies::GoogleOauth2 do
       subject.build_access_token
     end
 
+    it 'should use the request_uri from params if this not an AJAX request (request from installed app) with a code parameter' do
+      allow(request).to receive(:xhr?).and_return(false)
+      allow(request).to receive(:params).and_return('code' => 'valid_code', 'redirect_uri' => 'redirect_uri')
+
+      client = double(:client)
+      auth_code = double(:auth_code)
+      allow(client).to receive(:auth_code).and_return(auth_code)
+      expect(subject).to receive(:client).and_return(client)
+      expect(auth_code).to receive(:get_token).with('valid_code', { :redirect_uri => 'redirect_uri'}, {})
+
+      expect(subject).not_to receive(:orig_build_access_token)
+      subject.build_access_token
+    end
+
     it 'should read access_token from hash if this is not an AJAX request with a code parameter' do
       allow(request).to receive(:xhr?).and_return(false)
       allow(request).to receive(:params).and_return('id_token' => 'valid_id_token', 'access_token' => 'valid_access_token')


### PR DESCRIPTION
custom_build_access_token can now get a redirect_uri parameter from the request in order to override the default redirect_uri set in the configuration. 

This is useful if an installed application wants to submit an authorization code via omniauth-google-oauth2 since it is producing a redirect_uri_mismatch error if the right redirect_uri is not used.