### PR TITLE
Update documentation to reflect 'hd' provider option

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ You can configure several options, which you pass in to the `provider` method vi
 
 * `access_type`: Defaults to `offline`, so a refresh token is sent to be used when the user is not present at the browser. Can be set to `online`. Note that if you need a refresh token, google requires you to also to specify the option `prompt: 'consent'`, which is not a default.
 
+* `hd`: (Optional) Limit sign-in to a particular Google Apps hosted domain.  More information at: https://developers.google.com/accounts/docs/OpenIDConnect#hd-param
+
 * `login_hint`: When your app knows which user it is trying to authenticate, it can provide this parameter as a hint to the authentication server. Passing this hint suppresses the account chooser and either pre-fill the email box on the sign-in form, or select the proper session (if the user is using multiple sign-in), which can help you avoid problems that occur if your app logs in the wrong user account. The value can be either an email address or the sub string, which is equivalent to the user's Google+ ID.
 
 * `include_granted_scopes`: If this is provided with the value true, and the authorization request is granted, the authorization will include any previous authorizations granted to this user/application combination for other scopes. See Google's [Incremental Autorization](https://developers.google.com/accounts/docs/OAuth2WebServer#incrementalAuth) for additional details.


### PR DESCRIPTION
Noticed this works just fine, but was missing from the documentation.