### PR TITLE
Override validation on JWT token for openid id_token

### DIFF
--- a/lib/omniauth/strategies/google_oauth2.rb
+++ b/lib/omniauth/strategies/google_oauth2.rb
@@ -56,7 +56,16 @@ module OmniAuth
       extra do
         hash = {}
         hash[:id_token] = access_token['id_token']
-        hash[:id_info] = JWT.decode( access_token['id_token'], nil, false).first unless access_token['id_token'].nil?
+        if !access_token['id_token'].nil?
+          hash[:id_info] = JWT.decode(
+            access_token['id_token'], nil, false, {
+              :verify_iss => true,
+              'iss' => 'accounts.google.com',
+              :verify_aud => true,
+              'aud' => options.client_id,
+              :verify_sub => false
+            }).first
+        end
         hash[:raw_info] = raw_info unless skip_info?
         hash[:raw_friend_info] = raw_friend_info(raw_info['sub']) unless skip_info? || options[:skip_friends]
         prune! hash

--- a/spec/omniauth/strategies/google_oauth2_spec.rb
+++ b/spec/omniauth/strategies/google_oauth2_spec.rb
@@ -276,7 +276,16 @@ describe OmniAuth::Strategies::GoogleOauth2 do
 
     describe 'id_token' do
       context 'when the id_token is passed into the access token' do
-        id_token = JWT.encode({'abc' => 'xyz'}, 'secret')
+        token_info =
+          {
+            'abc' => 'xyz',
+            'exp' => Time.now.to_i + 3600,
+            'nbf' => Time.now.to_i - 60,
+            'iat' => Time.now.to_i,
+            'aud' => 'appid',
+            'iss' => 'accounts.google.com',
+          }
+        id_token = JWT.encode(token_info, 'secret')
         let(:access_token) { OAuth2::AccessToken.from_hash(client, {'id_token' => id_token}) }
 
         it 'should include id_token when set on the access_token' do
@@ -284,7 +293,7 @@ describe OmniAuth::Strategies::GoogleOauth2 do
         end
 
         it 'should include id_info when id_token set on the access_token' do
-          expect(subject.extra).to include(:id_info => {'abc' => 'xyz'})
+          expect(subject.extra).to include(:id_info => token_info)
         end
       end
 


### PR DESCRIPTION
Until version 1.4.0 JWT will try to validate the token
for all fields provided. This changes in 1.4.1 but until then
we either need to specify the validation parameters
or dismiss them manually.