### PR TITLE
Validate as many assertions as possible in the id_token

### DIFF
--- a/lib/omniauth/strategies/google_oauth2.rb
+++ b/lib/omniauth/strategies/google_oauth2.rb
@@ -63,7 +63,11 @@ module OmniAuth
               'iss' => 'accounts.google.com',
               :verify_aud => true,
               'aud' => options.client_id,
-              :verify_sub => false
+              :verify_sub => false,
+              :verify_expiration => true,
+              :verify_not_before => true,
+              :verify_iat => true,
+              :verify_jti => false
             }).first
         end
         hash[:raw_info] = raw_info unless skip_info?


### PR DESCRIPTION
Explicitly configure validation of the assertions, enabling as many as we are able to.

My attempt at #169.