### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Here's an example of an authentication hash available in the callback by accessi
 
 ### Devise
 
-First define your application id and secret in "config/initializers/devise.rb"
+First define your application id and secret in `config/initializers/devise.rb`. Do not use the snippet mentioned in the [Usage](https://github.com/zquestz/omniauth-google-oauth2#usage) section.
 
 ```ruby
 config.omniauth :google_oauth2, "GOOGLE_CLIENT_ID", "GOOGLE_CLIENT_SECRET", { }


### PR DESCRIPTION
Many people use the snippet from Usage section and then configure the same thing with Devise.
This leads to strange error - see intridea/omniauth-oauth2#58. `Authentication failure! csrf_detected: OmniAuth::Strategies::OAuth2::CallbackError, csrf_detected`