### PR TITLE
Strip all image URL query parameters

### DIFF
--- a/lib/omniauth/strategies/google_oauth2.rb
+++ b/lib/omniauth/strategies/google_oauth2.rb
@@ -163,7 +163,7 @@ module OmniAuth
         # strip `sz` parameter (defaults to sz=50) which overrides `image_size` options
         return nil unless query_values
 
-        query_hash = query_values.delete_if { |key| key == "sz" }
+        query_hash = query_values.delete_if { |key, value| key == "sz" }
 
         # an empty Hash would cause a ? character in the URL: http://image.url?
         return nil if query_hash.empty?

--- a/omniauth-google-oauth2.gemspec
+++ b/omniauth-google-oauth2.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'omniauth-oauth2', '>= 1.1.1'
   gem.add_runtime_dependency 'jwt', '~> 1.0'
   gem.add_runtime_dependency 'multi_json', '~> 1.3'
+  gem.add_runtime_dependency 'addressable', '~> 2.3'
 
   gem.add_development_dependency 'rspec', '>= 2.14.0'
   gem.add_development_dependency 'rake'

--- a/spec/omniauth/strategies/google_oauth2_spec.rb
+++ b/spec/omniauth/strategies/google_oauth2_spec.rb
@@ -420,6 +420,24 @@ describe OmniAuth::Strategies::GoogleOauth2 do
         expect(subject.info[:image]).to eq('https://lh3.googleusercontent.com/url/s50/photo.jpg')
       end
 
+      it 'should handle a picture with a size query parameter correctly' do
+        @options = {:image_size => 50}
+        allow(subject).to receive(:raw_info) { {'picture' => 'https://lh3.googleusercontent.com/url/photo.jpg?sz=50'} }
+        expect(subject.info[:image]).to eq('https://lh3.googleusercontent.com/url/s50/photo.jpg')
+      end
+
+      it 'should handle a picture with a size query parameter and other valid query parameters correctly' do
+        @options = {:image_size => 50}
+        allow(subject).to receive(:raw_info) { {'picture' => 'https://lh3.googleusercontent.com/url/photo.jpg?sz=50&hello=true&life=42'} }
+        expect(subject.info[:image]).to eq('https://lh3.googleusercontent.com/url/s50/photo.jpg?hello=true&life=42')
+      end
+
+      it 'should handle a picture with other valid query parameters correctly' do
+        @options = {:image_size => 50}
+        allow(subject).to receive(:raw_info) { {'picture' => 'https://lh3.googleusercontent.com/url/photo.jpg?hello=true&life=42'} }
+        expect(subject.info[:image]).to eq('https://lh3.googleusercontent.com/url/s50/photo.jpg?hello=true&life=42')
+      end
+
       it 'should return the image with width and height specified in the `image_size` option' do
         @options = {:image_size => {:width => 50, :height => 40}}
         allow(subject).to receive(:raw_info) { {'picture' => 'https://lh3.googleusercontent.com/url/photo.jpg'} }
@@ -455,7 +473,7 @@ describe OmniAuth::Strategies::GoogleOauth2 do
       allow(subject).to receive(:raw_info) { {'picture' => 'https://lh3.googleusercontent.com/url/photo.jpg'} }
       expect(subject.info[:image]).to eq('https://lh3.googleusercontent.com/url/photo.jpg')
     end
-    
+
     it 'should return correct image if google image url has double https' do
       allow(subject).to receive(:raw_info) { {'picture' => 'https:https://lh3.googleusercontent.com/url/photo.jpg'} }
       expect(subject.info[:image]).to eq('https://lh3.googleusercontent.com/url/photo.jpg')


### PR DESCRIPTION
Fixes #166 once again since Google started injecting
query parameters with `?z=50` to return a default size of 50
with all profile image URLs even when an explicit size is requested.

This means that even when we receive a URL like:

https://lh6.googleusercontent.com/-lDP57qXndCU/AAAAAAAAAAI/AAAAAAAEeVQ/M3c432SPq4I/s160-c/photo.jpg?sz=50

It will be converted to:
https://lh6.googleusercontent.com/-lDP57qXndCU/AAAAAAAAAAI/AAAAAAAEeVQ/M3c432SPq4I/s160-c/photo.jpg