### PR TITLE
Allow user to disable JWT decoding via skip_jwt option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,21 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## 0.2.7 - 2014-10-26
+## 0.2.8 - 2015-10-01
+
+### Added
+- Added skip_jwt option to bypass JWT decoding in case you get decoding errors.
+
+### Deprecated
+- Nothing.
+
+### Removed
+- Nothing.
+
+### Fixed
+- Resolved JWT::InvalidIatError. https://github.com/zquestz/omniauth-google-oauth2/issues/195
+
+## 0.2.7 - 2015-09-25
 
 ### Added
 - Now strips out the 'sz' parameter from profile image urls.

--- a/lib/omniauth/strategies/google_oauth2.rb
+++ b/lib/omniauth/strategies/google_oauth2.rb
@@ -11,11 +11,9 @@ module OmniAuth
       DEFAULT_SCOPE = "email,profile"
 
       option :name, 'google_oauth2'
-
       option :skip_friends, true
-
       option :skip_image_info, true
-
+      option :skip_jwt, false
       option :authorize_options, [:access_type, :hd, :login_hint, :prompt, :request_visible_actions, :scope, :state, :redirect_uri, :include_granted_scopes, :openid_realm]
 
       option :client_options, {
@@ -59,7 +57,7 @@ module OmniAuth
       extra do
         hash = {}
         hash[:id_token] = access_token['id_token']
-        if !access_token['id_token'].nil?
+        if !options[:skip_jwt] && !access_token['id_token'].nil?
           hash[:id_info] = JWT.decode(
             access_token['id_token'], nil, false, {
               :verify_iss => true,

--- a/spec/omniauth/strategies/google_oauth2_spec.rb
+++ b/spec/omniauth/strategies/google_oauth2_spec.rb
@@ -293,7 +293,17 @@ describe OmniAuth::Strategies::GoogleOauth2 do
           expect(subject.extra).to include(:id_token => id_token)
         end
 
-        it 'should include id_info when id_token set on the access_token' do
+        it 'should include id_info when id_token is set on the access_token and skip_jwt is false' do
+          subject.options[:skip_jwt] = false
+          expect(subject.extra).to include(:id_info => token_info)
+        end
+
+        it 'should not include id_info when id_token is set on the access_token and skip_jwt is true' do
+          subject.options[:skip_jwt] = true
+          expect(subject.extra).not_to have_key(:id_info)
+        end
+
+        it 'should include id_info when id_token is set on the access_token by default' do
           expect(subject.extra).to include(:id_info => token_info)
         end
       end


### PR DESCRIPTION
This is intended to resolve issues around JWT decoding. 

https://github.com/zquestz/omniauth-google-oauth2/issues/195