### PR TITLE
Removes typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ class ApplicationController < ActionController::Base
 ...
 ```
 
-and add ```skip_before_filter :verify_authenticity_token``` in your omniauth callback controller because it is already verified by omniauth state. And then you no need to add ```:provider_ignores_state => true``` in your omniauth initializer.
+and add ```skip_before_filter :verify_authenticity_token``` in your omniauth callback controller because it is already verified by omniauth state. And then you need to add ```:provider_ignores_state => true``` in your omniauth initializer.
 
 ## Fixing Protocol Mismatch for `redirect_uri` in Rails
 


### PR DESCRIPTION
In the line "And then you no need to add..." It would appear there is no need for the "no". Contained under [Omniauth state](https://github.com/zquestz/omniauth-google-oauth2#omniauth-state)