### PR TITLE
use callback_url without query_string when building access_token

### DIFF
--- a/lib/omniauth/strategies/google_oauth2.rb
+++ b/lib/omniauth/strategies/google_oauth2.rb
@@ -100,13 +100,17 @@ module OmniAuth
         elsif verify_token(request.params['id_token'], request.params['access_token'])
           ::OAuth2::AccessToken.from_hash(client, request.params.dup)
         else
-          orig_build_access_token
+          verifier = request.params["code"]
+          client.auth_code.get_token(verifier, get_token_options(callback_url), deep_symbolize(options.auth_token_params))
         end
       end
-      alias_method :orig_build_access_token, :build_access_token
       alias_method :build_access_token, :custom_build_access_token
 
       private
+
+      def callback_url
+        options[:redirect_uri] || (full_host + script_name + callback_path)
+      end
 
       def get_token_options(redirect_uri)
         { :redirect_uri => redirect_uri }.merge(token_params.to_hash(:symbolize_keys => true))


### PR DESCRIPTION
after `callback_url` override was removed in gem `omniauth-oauth2` in version 1.4.0
https://github.com/intridea/omniauth-oauth2/commit/26152673224aca5c3e918bcc83075dbb0659717f

there is a `build_access_token` error:
```
OAuth2::Error: redirect_uri_mismatch:
{
  "error" : "redirect_uri_mismatch"
}
```
this error can be fixed with `callback_url` override, similarly as it was in previous versions of the gem `omniauth-oauth2` 