### PR TITLE
Replace Addressable::URI with standard lib URI

### DIFF
--- a/lib/omniauth/strategies/google_oauth2.rb
+++ b/lib/omniauth/strategies/google_oauth2.rb
@@ -1,7 +1,7 @@
 require 'multi_json'
 require 'jwt'
 require 'omniauth/strategies/oauth2'
-require 'addressable/uri'
+require 'uri'
 
 module OmniAuth
   module Strategies
@@ -130,7 +130,7 @@ module OmniAuth
       def image_url
         return nil unless raw_info['picture']
 
-        u = Addressable::URI.parse(raw_info['picture'].gsub('https:https', 'https'))
+        u = URI.parse(raw_info['picture'].gsub('https:https', 'https'))
 
         path_index = u.path.to_s.index('/photo.jpg')
 
@@ -139,7 +139,7 @@ module OmniAuth
           u.path = u.path.gsub('//', '/')
         end
 
-        u.query_values = strip_unnecessary_query_parameters(u.query_values)
+        u.query = strip_unnecessary_query_parameters(u.query)
 
         u.to_s
       end
@@ -161,16 +161,18 @@ module OmniAuth
         '/' + image_params.join('-')
       end
 
-      def strip_unnecessary_query_parameters(query_values)
+      def strip_unnecessary_query_parameters(query_parameters)
         # strip `sz` parameter (defaults to sz=50) which overrides `image_size` options
-        return nil unless query_values
+        return nil if query_parameters.nil?
 
-        query_hash = query_values.delete_if { |key, value| key == "sz" }
+        params = CGI.parse(query_parameters)
+        stripped_params = params.delete_if { |key| key == "sz" }
 
-        # an empty Hash would cause a ? character in the URL: http://image.url?
-        return nil if query_hash.empty?
+        # don't return an empty Hash since that would result
+        # in URLs with a trailing ? character: http://image.url?
+        return nil if stripped_params.empty?
 
-        query_hash
+        URI.encode_www_form(stripped_params)
       end
 
       def verify_token(access_token)

--- a/omniauth-google-oauth2.gemspec
+++ b/omniauth-google-oauth2.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'omniauth-oauth2', '>= 1.3.1'
   gem.add_runtime_dependency 'jwt', '~> 1.0'
   gem.add_runtime_dependency 'multi_json', '~> 1.3'
-  gem.add_runtime_dependency 'addressable', '~> 2.3'
 
   gem.add_development_dependency 'rspec', '>= 2.14.0'
   gem.add_development_dependency 'rake'


### PR DESCRIPTION
I introduced this in 4734a50cf6053a7eed3d2997d2c7cac987adc359 not knowing the serious performance issues with the addressable gem that @SamSaffron pointed out in: https://github.com/zquestz/omniauth-google-oauth2/pull/193#issuecomment-170447701

I expect tests to pass because I'm essentially reverting to the code I originally proposed in https://github.com/zquestz/omniauth-google-oauth2/pull/193 with the first commit: c7c9cfa38c32661f7e71da0672006ddeb5bfa97f