### PR TITLE
Allow to set more than one hosted domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ You can configure several options, which you pass in to the `provider` method vi
 
 * `access_type`: Defaults to `offline`, so a refresh token is sent to be used when the user is not present at the browser. Can be set to `online`. More about [offline access](https://developers.google.com/identity/protocols/OAuth2WebServer#offline)
 
-* `hd`: (Optional) Limit sign-in to a particular Google Apps hosted domain.  More information at: https://developers.google.com/accounts/docs/OpenIDConnect#hd-param
+* `hd`: (Optional) Limit sign-in to a particular Google Apps hosted domain. This can be simply string `'domain.com'` or an array `%w(domain.com domain.co)`. More information at: https://developers.google.com/accounts/docs/OpenIDConnect#hd-param
 
 * `skip_jwt`: Skip JWT processing. This is for users who are seeing JWT decoding errors with the `iat` field.
 

--- a/lib/omniauth/strategies/google_oauth2.rb
+++ b/lib/omniauth/strategies/google_oauth2.rb
@@ -189,7 +189,9 @@ module OmniAuth
       def verify_hd(access_token)
         return true unless options.hd
         @raw_info ||= access_token.get('https://www.googleapis.com/plus/v1/people/me/openIdConnect').parsed
-        raise CallbackError.new(:invalid_hd, "Invalid Hosted Domain") unless @raw_info['hd'] == options.hd
+        allowed_hosted_domains = Array(options.hd)
+
+        raise CallbackError.new(:invalid_hd, "Invalid Hosted Domain") unless allowed_hosted_domains.include? @raw_info['hd']
         true
       end
     end

--- a/spec/omniauth/strategies/google_oauth2_spec.rb
+++ b/spec/omniauth/strategies/google_oauth2_spec.rb
@@ -615,8 +615,20 @@ describe OmniAuth::Strategies::GoogleOauth2 do
       expect(subject.send(:verify_hd, access_token)).to eq(true)
     end
 
+    it 'should verify hd if options hd is set as an array and is correct' do
+      subject.options.hd = ['example.com', 'example.co']
+      expect(subject.send(:verify_hd, access_token)).to eq(true)
+    end
+
     it 'should raise error if options hd is set and wrong' do
       subject.options.hd = 'invalid.com'
+      expect {
+        subject.send(:verify_hd, access_token)
+      }.to raise_error(OmniAuth::Strategies::GoogleOauth2::CallbackError)
+    end
+
+    it 'should raise error if options hd is set as an array and is not correct' do
+      subject.options.hd = ['invalid.com', 'invalid.co']
       expect {
         subject.send(:verify_hd, access_token)
       }.to raise_error(OmniAuth::Strategies::GoogleOauth2::CallbackError)


### PR DESCRIPTION
Changes:
- allow more than one hd (Hosted Domain)
- added tests for this case
- updated README

This is very helpful when your app needs to support several hosted domains.