### PR TITLE
Added support for JWT leeway and bumped to 0.4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ before_install:
   - gem update --system 2.1.11
 language: ruby
 rvm:
-  - "1.9.3"
   - "2.0.0"
   - "2.1.0"
   - "2.2.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,22 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 0.4.0 - 2016-03-11
+
+### Added
+- Addedd ability to specify multiple hosted domains.
+- Added a default leeway of 1 minute to JWT token validation.
+- Now requires ruby-jwt 1.5.x.
+
+### Deprecated
+- Nothing.
+
+### Removed
+- Removed support for ruby 1.9.3 as ruby-jwt 1.5.x does not support it.
+
+### Fixed
+- Nothing.
+
 ## 0.3.1 - 2016-01-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -74,7 +74,9 @@ You can configure several options, which you pass in to the `provider` method vi
 
 * `hd`: (Optional) Limit sign-in to a particular Google Apps hosted domain. This can be simply string `'domain.com'` or an array `%w(domain.com domain.co)`. More information at: https://developers.google.com/accounts/docs/OpenIDConnect#hd-param
 
-* `skip_jwt`: Skip JWT processing. This is for users who are seeing JWT decoding errors with the `iat` field.
+* `jwt_leeway`: Number of seconds passed to the JWT library as leeway. Defaults to 60 seconds.
+
+* `skip_jwt`: Skip JWT processing. This is for users who are seeing JWT decoding errors with the `iat` field. Always try adjusting the leeway before disabling JWT processing.
 
 * `login_hint`: When your app knows which user it is trying to authenticate, it can provide this parameter as a hint to the authentication server. Passing this hint suppresses the account chooser and either pre-fill the email box on the sign-in form, or select the proper session (if the user is using multiple sign-in), which can help you avoid problems that occur if your app logs in the wrong user account. The value can be either an email address or the sub string, which is equivalent to the user's Google+ ID.
 
@@ -303,7 +305,7 @@ OmniAuth.config.full_host = Rails.env.production? ? 'https://domain.com' : 'http
 
 ## License
 
-Copyright (c) 2015 by Josh Ellithorpe
+Copyright (c) 2016 by Josh Ellithorpe
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/lib/omniauth/google_oauth2/version.rb
+++ b/lib/omniauth/google_oauth2/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module GoogleOauth2
-    VERSION = "0.3.1"
+    VERSION = "0.4.0"
   end
 end

--- a/lib/omniauth/strategies/google_oauth2.rb
+++ b/lib/omniauth/strategies/google_oauth2.rb
@@ -14,6 +14,7 @@ module OmniAuth
       option :skip_friends, true
       option :skip_image_info, true
       option :skip_jwt, false
+      option :jwt_leeway, 60
       option :authorize_options, [:access_type, :hd, :login_hint, :prompt, :request_visible_actions, :scope, :state, :redirect_uri, :include_granted_scopes, :openid_realm]
 
       option :client_options, {
@@ -68,7 +69,8 @@ module OmniAuth
               :verify_expiration => true,
               :verify_not_before => true,
               :verify_iat => true,
-              :verify_jti => false
+              :verify_jti => false,
+              :leeway => options[:jwt_leeway]
             }).first
         end
         hash[:raw_info] = raw_info unless skip_info?

--- a/omniauth-google-oauth2.gemspec
+++ b/omniauth-google-oauth2.gemspec
@@ -14,9 +14,11 @@ Gem::Specification.new do |gem|
   gem.files         = `git ls-files`.split("\n")
   gem.require_paths = ["lib"]
 
+  gem.required_ruby_version = '>= 2.0'
+
   gem.add_runtime_dependency 'omniauth', '>= 1.1.1'
   gem.add_runtime_dependency 'omniauth-oauth2', '>= 1.3.1'
-  gem.add_runtime_dependency 'jwt', '~> 1.0'
+  gem.add_runtime_dependency 'jwt', '~> 1.5.0'
   gem.add_runtime_dependency 'multi_json', '~> 1.3'
 
   gem.add_development_dependency 'rspec', '>= 2.14.0'


### PR DESCRIPTION
Lots of users experience time drift on their servers. Recent versions of the ruby-jwt library allow a leeway to be passed in. This is now fully supported in this gem, with a default of 60 seconds. If you don't want to use the leeway you can easily opt out by setting `:jwt_leeway` to 0. 