### PR TITLE
Add `issued_at_leeway` as a config parameter

### DIFF
--- a/lib/omniauth/strategies/google_oauth2.rb
+++ b/lib/omniauth/strategies/google_oauth2.rb
@@ -68,7 +68,8 @@ module OmniAuth
               :verify_expiration => true,
               :verify_not_before => true,
               :verify_iat => true,
-              :verify_jti => false
+              :verify_jti => false,
+              :leeway => options[:issued_at_leeway] || 0
             }).first
         end
         hash[:raw_info] = raw_info unless skip_info?

--- a/omniauth-google-oauth2.gemspec
+++ b/omniauth-google-oauth2.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency 'omniauth', '>= 1.1.1'
   gem.add_runtime_dependency 'omniauth-oauth2', '>= 1.3.1'
-  gem.add_runtime_dependency 'jwt', '~> 1.0'
+  gem.add_runtime_dependency 'jwt', '>= 1.5.2'
   gem.add_runtime_dependency 'multi_json', '~> 1.3'
 
   gem.add_development_dependency 'rspec', '>= 2.14.0'


### PR DESCRIPTION
When receiving the JSON Web Token response back from Google, it includes an Issued At timestamp in unix time. If your clock is behind this timestamp, you will receive `JWT::InvalidIatError` since by default, it does not allow future tokens.

Adding leeway as a configurable option makes it easy to allow for future tokens with whatever tolerance you are comfortable with in the `config.omniauth` statement.

Example Usage:
```ruby
config.omniauth :google_oauth2, ENV['GOOGLE_OAUTH_ID'], ENV['GOOGLE_OAUTH_SECRET'], {
    scope: "email", issued_at_leeway: 300  # Allow 5 minutes into the future
 }
```
This is in response to #195 