### PR TITLE
Added tweak to Omniauth callback example

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
         flash[:notice] = I18n.t "devise.omniauth_callbacks.success", :kind => "Google"
         sign_in_and_redirect @user, :event => :authentication
       else
-        session["devise.google_data"] = request.env["omniauth.auth"]
+        session["devise.google_data"] = request.env["omniauth.auth"].except(:extra) #Removing extra as it can overflow some session stores
         redirect_to new_user_registration_url
       end
   end


### PR DESCRIPTION
Long time, man.  We should catch up.

I was just pulling this into a project and found that the large oauth payload can overflow cookie sizes if you use cookies as your sesion store.  In general, it is probably not needed to store the extra data either, so added code to remove that and comment it out.