### PR TITLE
Push error messages along on callback errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
         sign_in_and_redirect @user, :event => :authentication
       else
         session["devise.google_data"] = request.env["omniauth.auth"]
-        redirect_to new_user_registration_url
+        redirect_to new_user_registration_url, alert: @user.errors.full_messages.join("\n")
       end
   end
 end


### PR DESCRIPTION
Separated this from the other PR as it is a bit more debatable.

When the example callback hits an error, it redirects out without any info about what the problem was.  This makes debugging pretty hard.  It really needs to either log some info, render the login view that can show the errors on the @user object, or pass through the errors from @user converted into a string in the flash.  The other two options take more context on the app than appropriate in a sample, so added the last into the code.  This should at least help folks in their debugging.