### PR TITLE
Support passing a Proc to the hd option

### DIFF
--- a/lib/omniauth/strategies/google_oauth2.rb
+++ b/lib/omniauth/strategies/google_oauth2.rb
@@ -192,6 +192,8 @@ module OmniAuth
       def verify_hd(access_token)
         return true unless options.hd
         @raw_info ||= access_token.get('https://www.googleapis.com/plus/v1/people/me/openIdConnect').parsed
+        
+        options.hd = options.hd.call if options.hd.is_a? Proc
         allowed_hosted_domains = Array(options.hd)
 
         raise CallbackError.new(:invalid_hd, "Invalid Hosted Domain") unless allowed_hosted_domains.include? @raw_info['hd']

--- a/spec/omniauth/strategies/google_oauth2_spec.rb
+++ b/spec/omniauth/strategies/google_oauth2_spec.rb
@@ -624,6 +624,16 @@ describe OmniAuth::Strategies::GoogleOauth2 do
       subject.options.hd = ['example.com', 'example.co']
       expect(subject.send(:verify_hd, access_token)).to eq(true)
     end
+    
+    it 'should verify hd if options hd is set as an Proc and is correct' do
+      subject.options.hd = Proc.new { 'example.com' }
+      expect(subject.send(:verify_hd, access_token)).to eq(true)
+    end
+    
+    it 'should verify hd if options hd is set as an Proc returning an array and is correct' do
+      subject.options.hd = Proc.new { ['example.com', 'example.co'] }
+      expect(subject.send(:verify_hd, access_token)).to eq(true)
+    end
 
     it 'should raise error if options hd is set and wrong' do
       subject.options.hd = 'invalid.com'


### PR DESCRIPTION
Allows for syntax like this:

```
  provider :google_oauth2, 'XX', 'XX', {
    hd: Proc.new {
      User.allowed_email_domains
    }
  }
```