### PR TITLE
UID should always be sub

### DIFF
--- a/lib/omniauth/strategies/google_oauth2.rb
+++ b/lib/omniauth/strategies/google_oauth2.rb
@@ -41,7 +41,7 @@ module OmniAuth
         end
       end
 
-      uid { raw_info['sub'] || verified_email }
+      uid { raw_info['sub'] }
 
       info do
         prune!({


### PR DESCRIPTION
According to -> https://developers.google.com/identity/protocols/OpenIDConnect#server-flow
(scroll down a bit)

"An identifier for the user, unique among all Google accounts and never reused. A Google account can have multiple emails at different points in time, but the sub value is never changed. Use sub within your application as the unique-identifier key for the user."

It is always passed back. 