### PR TITLE
Update auth URIs

### DIFF
--- a/lib/omniauth/strategies/google_oauth2.rb
+++ b/lib/omniauth/strategies/google_oauth2.rb
@@ -22,9 +22,8 @@ module OmniAuth
       option :authorized_client_ids, []
 
       option :client_options,
-             site: 'https://accounts.google.com',
-             authorize_url: '/o/oauth2/auth',
-             token_url: '/o/oauth2/token'
+             authorize_url: 'https://accounts.google.com/o/oauth2/v2/auth',
+             token_url: 'https://www.googleapis.com/oauth2/v4/token'
 
       def authorize_params
         super.tap do |params|

--- a/spec/omniauth/strategies/google_oauth2_spec.rb
+++ b/spec/omniauth/strategies/google_oauth2_spec.rb
@@ -28,16 +28,16 @@ describe OmniAuth::Strategies::GoogleOauth2 do
   end
 
   describe '#client_options' do
-    it 'has correct site' do
-      expect(subject.client.site).to eq('https://accounts.google.com')
+    it 'does not have site' do
+      expect(subject.client.site).to eq(nil)
     end
 
     it 'has correct authorize_url' do
-      expect(subject.client.options[:authorize_url]).to eq('/o/oauth2/auth')
+      expect(subject.client.options[:authorize_url]).to eq('https://accounts.google.com/o/oauth2/v2/auth')
     end
 
     it 'has correct token_url' do
-      expect(subject.client.options[:token_url]).to eq('/o/oauth2/token')
+      expect(subject.client.options[:token_url]).to eq('https://www.googleapis.com/oauth2/v4/token')
     end
 
     describe 'overrides' do


### PR DESCRIPTION
Update URIs according to current Google docs. [Here](https://developers.google.com/identity/protocols/OAuth2WebServer#redirecting) is for initial redirect and for exchanging is [here](https://developers.google.com/identity/protocols/OAuth2WebServer#exchange-authorization-code)