### PR TITLE
Added device_id and device_name as potential authorize_options

### DIFF
--- a/lib/omniauth/strategies/google_oauth2.rb
+++ b/lib/omniauth/strategies/google_oauth2.rb
@@ -18,7 +18,7 @@ module OmniAuth
       option :skip_image_info, true
       option :skip_jwt, false
       option :jwt_leeway, 60
-      option :authorize_options, %i[access_type hd login_hint prompt request_visible_actions scope state redirect_uri include_granted_scopes openid_realm]
+      option :authorize_options, %i[access_type hd login_hint prompt request_visible_actions scope state redirect_uri include_granted_scopes openid_realm device_id, device_name]
       option :authorized_client_ids, []
 
       option :client_options,

--- a/lib/omniauth/strategies/google_oauth2.rb
+++ b/lib/omniauth/strategies/google_oauth2.rb
@@ -18,7 +18,7 @@ module OmniAuth
       option :skip_image_info, true
       option :skip_jwt, false
       option :jwt_leeway, 60
-      option :authorize_options, %i[access_type hd login_hint prompt request_visible_actions scope state redirect_uri include_granted_scopes openid_realm device_id, device_name]
+      option :authorize_options, %i[access_type hd login_hint prompt request_visible_actions scope state redirect_uri include_granted_scopes openid_realm device_id device_name]
       option :authorized_client_ids, []
 
       option :client_options,


### PR DESCRIPTION
When using a private IP range you'll get the following error: "That’s an error. Error: invalid_request device_id and device_name are required for private IP:"

If you specify those 2 arguments then Google will allow you to use OAuth.

I couldn't find any documentation for these two arguments, but I know specifiying them makes it work :)