### PR TITLE
Allow skipping of verification of iss via a config option

### DIFF
--- a/lib/omniauth/strategies/google_oauth2.rb
+++ b/lib/omniauth/strategies/google_oauth2.rb
@@ -20,6 +20,7 @@ module OmniAuth
       option :jwt_leeway, 60
       option :authorize_options, %i[access_type hd login_hint prompt request_visible_actions scope state redirect_uri include_granted_scopes openid_realm device_id device_name]
       option :authorized_client_ids, []
+      option :verify_iss, true
 
       option :client_options,
              authorize_url: 'https://accounts.google.com/o/oauth2/v2/auth',
@@ -59,7 +60,7 @@ module OmniAuth
         hash[:id_token] = access_token['id_token']
         if !options[:skip_jwt] && !access_token['id_token'].nil?
           hash[:id_info] = JWT.decode(
-            access_token['id_token'], nil, false, verify_iss: true,
+            access_token['id_token'], nil, false, verify_iss: options.verify_iss,
                                                   iss: 'accounts.google.com',
                                                   verify_aud: true,
                                                   aud: options.client_id,

--- a/spec/omniauth/strategies/google_oauth2_spec.rb
+++ b/spec/omniauth/strategies/google_oauth2_spec.rb
@@ -593,6 +593,37 @@ describe OmniAuth::Strategies::GoogleOauth2 do
     end
   end
 
+  describe 'verify_iss option' do
+    before(:each) do
+      subject.options.client_options[:connection_build] = proc do |builder|
+        builder.request :url_encoded
+        builder.adapter :test do |stub|
+          stub.get('/oauth2/v3/tokeninfo?access_token=invalid_iss_token') do
+            [200, { 'Content-Type' => 'application/json; charset=UTF-8' },
+             MultiJson.encode(
+               aud: '000000000000.apps.googleusercontent.com',
+               sub: '123456789',
+               email_verified: 'true',
+               email: 'example@example.com',
+               access_type: 'offline',
+               scope: 'profile email',
+               expires_in: 436,
+               iss: 'foobar.com'
+             )]
+          end
+        end
+      end
+      subject.options.authorized_client_ids = ['000000000000.apps.googleusercontent.com']
+      subject.options.client_id = '000000000000.apps.googleusercontent.com'
+      subject.options[:verify_iss] = false
+    end
+
+    it 'should verify token if the iss does not match options.expected_iss' do
+      result = subject.send(:verify_token, 'invalid_iss_token')
+      expect(result).to eq(true)
+    end
+  end
+
   describe 'verify_token' do
     before(:each) do
       subject.options.client_options[:connection_build] = proc do |builder|


### PR DESCRIPTION
this would be a workaround for issue #292. Google's own libraries for
oauth don't verify iss, and it seems that they've recently changed the
iss to `http://accounts.google.com` from `accounts.google.com`