### PR TITLE
changed JWT.decode iss: key to https://... on the strategy.rb

### DIFF
--- a/lib/omniauth/strategies/google_oauth2.rb
+++ b/lib/omniauth/strategies/google_oauth2.rb
@@ -62,7 +62,7 @@ module OmniAuth
         if !options[:skip_jwt] && !access_token['id_token'].nil?
           hash[:id_info] = JWT.decode(
             access_token['id_token'], nil, false, verify_iss: options.verify_iss,
-                                                  iss: 'accounts.google.com',
+                                                  iss: 'https://accounts.google.com',
                                                   verify_aud: true,
                                                   aud: options.client_id,
                                                   verify_sub: false,

--- a/spec/omniauth/strategies/google_oauth2_spec.rb
+++ b/spec/omniauth/strategies/google_oauth2_spec.rb
@@ -317,7 +317,7 @@ describe OmniAuth::Strategies::GoogleOauth2 do
             'nbf' => Time.now.to_i - 60,
             'iat' => Time.now.to_i,
             'aud' => 'appid',
-            'iss' => 'accounts.google.com'
+            'iss' => 'https://accounts.google.com'
           }
         id_token = JWT.encode(token_info, 'secret')
         let(:access_token) { OAuth2::AccessToken.from_hash(client, 'id_token' => id_token) }


### PR DESCRIPTION
I was using 0.5.1 and ran into `JWT::InvalidIssuerError (Invalid issuer. Expected accounts.google.com, received https://accounts.google.com)`
Just changed the following in the strategy rb and it worked. I guess it has nothing to do with JWT?