### PR TITLE
fixing issue #301 - hd=* should be supported

### DIFF
--- a/lib/omniauth/strategies/google_oauth2.rb
+++ b/lib/omniauth/strategies/google_oauth2.rb
@@ -206,7 +206,7 @@ module OmniAuth
         options.hd = options.hd.call if options.hd.is_a? Proc
         allowed_hosted_domains = Array(options.hd)
 
-        raise CallbackError.new(:invalid_hd, 'Invalid Hosted Domain') unless allowed_hosted_domains.include? @raw_info['hd']
+        raise CallbackError.new(:invalid_hd, 'Invalid Hosted Domain') unless allowed_hosted_domains.include?(@raw_info['hd']) || options.hd == '*'
         true
       end
     end

--- a/spec/omniauth/strategies/google_oauth2_spec.rb
+++ b/spec/omniauth/strategies/google_oauth2_spec.rb
@@ -123,6 +123,11 @@ describe OmniAuth::Strategies::GoogleOauth2 do
         @options = { hd: nil }
         expect(subject.authorize_params['hd']).to eq(nil)
       end
+
+      it 'should set the hd parameter to * if set (only allows G Suite emails)' do
+        @options = { hd: '*' }
+        expect(subject.authorize_params['hd']).to eq('*')
+      end
     end
 
     describe 'login_hint' do


### PR DESCRIPTION
According to the openID documentation hd=* is a valid option to only allow G Suite emails.