### PR TITLE
Drop MultiJson dependency

### DIFF
--- a/lib/omniauth/strategies/google_oauth2.rb
+++ b/lib/omniauth/strategies/google_oauth2.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'multi_json'
 require 'jwt'
 require 'omniauth/strategies/oauth2'
 require 'uri'

--- a/omniauth-google-oauth2.gemspec
+++ b/omniauth-google-oauth2.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'omniauth', '>= 1.1.1'
   gem.add_runtime_dependency 'omniauth-oauth2', '>= 1.3.1'
   gem.add_runtime_dependency 'jwt', '~> 1.5'
-  gem.add_runtime_dependency 'multi_json', '~> 1.3'
 
   gem.add_development_dependency 'rspec', '~> 3.6'
   gem.add_development_dependency 'rake', '~> 12.0'

--- a/spec/omniauth/strategies/google_oauth2_spec.rb
+++ b/spec/omniauth/strategies/google_oauth2_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'json'
 require 'omniauth-google-oauth2'
 
 describe OmniAuth::Strategies::GoogleOauth2 do
@@ -605,7 +606,7 @@ describe OmniAuth::Strategies::GoogleOauth2 do
         builder.adapter :test do |stub|
           stub.get('/oauth2/v3/tokeninfo?access_token=invalid_iss_token') do
             [200, { 'Content-Type' => 'application/json; charset=UTF-8' },
-             MultiJson.encode(
+             JSON.dump(
                aud: '000000000000.apps.googleusercontent.com',
                sub: '123456789',
                email_verified: 'true',
@@ -635,7 +636,7 @@ describe OmniAuth::Strategies::GoogleOauth2 do
         builder.request :url_encoded
         builder.adapter :test do |stub|
           stub.get('/oauth2/v3/tokeninfo?access_token=valid_access_token') do
-            [200, { 'Content-Type' => 'application/json; charset=UTF-8' }, MultiJson.encode(
+            [200, { 'Content-Type' => 'application/json; charset=UTF-8' }, JSON.dump(
               aud: '000000000000.apps.googleusercontent.com',
               sub: '123456789',
               email_verified: 'true',
@@ -646,7 +647,7 @@ describe OmniAuth::Strategies::GoogleOauth2 do
             )]
           end
           stub.get('/oauth2/v3/tokeninfo?access_token=invalid_access_token') do
-            [400, { 'Content-Type' => 'application/json; charset=UTF-8' }, MultiJson.encode(error_description: 'Invalid Value')]
+            [400, { 'Content-Type' => 'application/json; charset=UTF-8' }, JSON.dump(error_description: 'Invalid Value')]
           end
         end
       end
@@ -679,7 +680,7 @@ describe OmniAuth::Strategies::GoogleOauth2 do
         builder.request :url_encoded
         builder.adapter :test do |stub|
           stub.get('/plus/v1/people/me/openIdConnect') do
-            [200, { 'Content-Type' => 'application/json; charset=UTF-8' }, MultiJson.encode(
+            [200, { 'Content-Type' => 'application/json; charset=UTF-8' }, JSON.dump(
               hd: 'example.com'
             )]
           end
@@ -694,7 +695,7 @@ describe OmniAuth::Strategies::GoogleOauth2 do
           builder.request :url_encoded
           builder.adapter :test do |stub|
             stub.get('/plus/v1/people/me/openIdConnect') do
-              [200, { 'Content-Type' => 'application/json; charset=UTF-8' }, MultiJson.encode({})]
+              [200, { 'Content-Type' => 'application/json; charset=UTF-8' }, JSON.dump({})]
             end
           end
         end


### PR DESCRIPTION
The `multi_json` gem has been added in https://github.com/zquestz/omniauth-google-oauth2/commit/4c47ef65f326b7334189c0b861a83db52598f171, but it is no longer encouraged to use `multi_json` due to this reason: https://github.com/intridea/multi_json/pull/113#issuecomment-17668823. In addition, The `MultiJson` is only used in the specs, so there's no reason it should be a runtime dependency.