### PR TITLE
Fully qualify JWT class name

### DIFF
--- a/lib/omniauth/strategies/google_oauth2.rb
+++ b/lib/omniauth/strategies/google_oauth2.rb
@@ -60,7 +60,7 @@ module OmniAuth
         hash = {}
         hash[:id_token] = access_token['id_token']
         if !options[:skip_jwt] && !access_token['id_token'].nil?
-          hash[:id_info] = JWT.decode(
+          hash[:id_info] = ::JWT.decode(
             access_token['id_token'], nil, false, verify_iss: options.verify_iss,
                                                   iss: 'accounts.google.com',
                                                   verify_aud: true,


### PR DESCRIPTION
If you are running both this strategy and the Omniauth::JWT strategy, when this library attempts to decode a `JWT`, the class name will resolve to `OmniAuth::Strategies::JWT`.

Fully qualify the `JWT` class name in order to resolve this collision.