### PR TITLE
Allow JWT 2.x

### DIFF
--- a/omniauth-google-oauth2.gemspec
+++ b/omniauth-google-oauth2.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.files         = `git ls-files`.split("\n")
   gem.require_paths = ['lib']
 
-  gem.required_ruby_version = '>= 2.0'
+  gem.required_ruby_version = '>= 2.1'
 
   gem.add_runtime_dependency 'jwt', '>= 1.5'
   gem.add_runtime_dependency 'omniauth', '>= 1.1.1'

--- a/omniauth-google-oauth2.gemspec
+++ b/omniauth-google-oauth2.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 2.0'
 
-  gem.add_runtime_dependency 'jwt', '~> 1.5'
+  gem.add_runtime_dependency 'jwt', '>= 1.5'
   gem.add_runtime_dependency 'omniauth', '>= 1.1.1'
   gem.add_runtime_dependency 'omniauth-oauth2', '>= 1.3.1'
 


### PR DESCRIPTION
Allowing JWT to be anything 1.5 or above, instead of limited to just 1.x greater than 1.5.

Also due to rubocop 0.50+ not allowing ruby 2.0.x anymore, made the minimum gem version 2.1.x.  Instead of increasing the minimum ruby version, could also peg the rubocop version to 0.49, since it's only used for development of the gem and revert the minimum ruby version back to ruby 2.0.

When pegging rubocop to "~> 0.49.0", then ended up getting the following rubocop error: 
```ruby
       +Inspecting 13 files
       +......C......
       +
       +Offenses:
       +
       +lib/omniauth-google-oauth2.rb:1:1: C: The name of this source file (omniauth-google-oauth2.rb) should use snake_case.
       +# frozen_string_literal: true
```

Relates to: https://github.com/zquestz/omniauth-google-oauth2/issues/305