### PR TITLE
Comment out provider name for sake of tutorial stability

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,6 @@ Here's an example of a possible configuration where the strategy name is changed
 Rails.application.config.middleware.use OmniAuth::Builder do
   provider :google_oauth2, ENV['GOOGLE_CLIENT_ID'], ENV['GOOGLE_CLIENT_SECRET'],
     {
-      # name: 'google',
       scope: 'email, profile, plus.me, http://gdata.youtube.com',
       prompt: 'select_account',
       image_aspect_ratio: 'square',

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Here's an example of a possible configuration where the strategy name is changed
 Rails.application.config.middleware.use OmniAuth::Builder do
   provider :google_oauth2, ENV['GOOGLE_CLIENT_ID'], ENV['GOOGLE_CLIENT_SECRET'],
     {
-      name: 'google',
+      # name: 'google',
       scope: 'email, profile, plus.me, http://gdata.youtube.com',
       prompt: 'select_account',
       image_aspect_ratio: 'square',


### PR DESCRIPTION
While following these instructions, I left the 'google' in as name of provider. This breaks the following instruction of using the `user_google_oauth2_omniauth_authorize_path` route.

I think it's a good idea to leave that commented out to avoid others falling into that pitfall.