### PR TITLE
Updates default URLs per recommendation from Google

### DIFF
--- a/lib/omniauth/strategies/google_oauth2.rb
+++ b/lib/omniauth/strategies/google_oauth2.rb
@@ -22,9 +22,9 @@ module OmniAuth
       option :verify_iss, true
 
       option :client_options,
-             site: 'https://accounts.google.com',
-             authorize_url: '/o/oauth2/auth',
-             token_url: '/o/oauth2/token'
+             site: 'https://oauth2.googleapis.com',
+             authorize_url: 'https://accounts.google.com/o/oauth2/auth',
+             token_url: '/token'
 
       def authorize_params
         super.tap do |params|

--- a/spec/omniauth/strategies/google_oauth2_spec.rb
+++ b/spec/omniauth/strategies/google_oauth2_spec.rb
@@ -30,15 +30,15 @@ describe OmniAuth::Strategies::GoogleOauth2 do
 
   describe '#client_options' do
     it 'has correct site' do
-      expect(subject.client.site).to eq('https://accounts.google.com')
+      expect(subject.client.site).to eq('https://oauth2.googleapis.com')
     end
 
     it 'has correct authorize_url' do
-      expect(subject.client.options[:authorize_url]).to eq('/o/oauth2/auth')
+      expect(subject.client.options[:authorize_url]).to eq('https://accounts.google.com/o/oauth2/auth')
     end
 
     it 'has correct token_url' do
-      expect(subject.client.options[:token_url]).to eq('/o/oauth2/token')
+      expect(subject.client.options[:token_url]).to eq('/token')
     end
 
     describe 'overrides' do


### PR DESCRIPTION
Google has recommended updating authentication endpoints
to those found in this commit.

Reference:
- https://github.com/googleapis/google-cloud-common/issues/260
- https://github.com/googleapis/google-auth-library-ruby/issues/155

Some evidence shows old URLs are causing intermittent issues; for
example, an elusive `invalid_grant` message was showing up for a
project I worked on recently, and disappeared with this change.
Possibly an issue with timeouts and/or deprioritization of these
older URLs, or something else that isn't immediately apparent.