### PR TITLE
Switch to using `userinfo` instead of G+ `plus.me` endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,8 +141,6 @@ Here's an example of an authentication hash available in the callback by accessi
       "exp" => 1496120719
     },
     "raw_info" => {
-      "kind" => "plus#personOpenIdConnect",
-      "gender" => "male",
       "sub" => "100000000000000000000",
       "name" => "John Smith",
       "given_name" => "John",

--- a/lib/omniauth/strategies/google_oauth2.rb
+++ b/lib/omniauth/strategies/google_oauth2.rb
@@ -11,6 +11,7 @@ module OmniAuth
       BASE_SCOPE_URL = 'https://www.googleapis.com/auth/'
       BASE_SCOPES = %w[profile email openid].freeze
       DEFAULT_SCOPE = 'email,profile'
+      USER_INFO_URL = 'https://www.googleapis.com/oauth2/v3/userinfo'.freeze
 
       option :name, 'google_oauth2'
       option :skip_friends, true
@@ -73,21 +74,11 @@ module OmniAuth
           ).first
         end
         hash[:raw_info] = raw_info unless skip_info?
-        hash[:raw_friend_info] = raw_friend_info(raw_info['sub']) unless skip_info? || options[:skip_friends]
-        hash[:raw_image_info] = raw_image_info(raw_info['sub']) unless skip_info? || options[:skip_image_info]
         prune! hash
       end
 
       def raw_info
-        @raw_info ||= access_token.get('https://www.googleapis.com/plus/v1/people/me/openIdConnect').parsed
-      end
-
-      def raw_friend_info(id)
-        @raw_friend_info ||= access_token.get("https://www.googleapis.com/plus/v1/people/#{id}/people/visible").parsed
-      end
-
-      def raw_image_info(id)
-        @raw_image_info ||= access_token.get("https://www.googleapis.com/plus/v1/people/#{id}?fields=image").parsed
+        @raw_info ||= access_token.get(USER_INFO_URL).parsed
       end
 
       def custom_build_access_token
@@ -202,7 +193,7 @@ module OmniAuth
       def verify_hd(access_token)
         return true unless options.hd
 
-        @raw_info ||= access_token.get('https://www.googleapis.com/plus/v1/people/me/openIdConnect').parsed
+        @raw_info ||= access_token.get(USER_INFO_URL).parsed
 
         options.hd = options.hd.call if options.hd.is_a? Proc
         allowed_hosted_domains = Array(options.hd)

--- a/spec/omniauth/strategies/google_oauth2_spec.rb
+++ b/spec/omniauth/strategies/google_oauth2_spec.rb
@@ -304,9 +304,7 @@ describe OmniAuth::Strategies::GoogleOauth2 do
       OAuth2::Client.new('abc', 'def') do |builder|
         builder.request :url_encoded
         builder.adapter :test do |stub|
-          stub.get('/plus/v1/people/me/openIdConnect') { [200, { 'content-type' => 'application/json' }, '{"sub": "12345"}'] }
-          stub.get('/plus/v1/people/12345/people/visible') { [200, { 'content-type' => 'application/json' }, '[{"foo":"bar"}]'] }
-          stub.get('/plus/v1/people/12345?fields=image') { [200, { 'content-type' => 'application/json' }, '{"image":"imageData"}'] }
+          stub.get('/oauth2/v3/userinfo') { [200, { 'content-type' => 'application/json' }, '{"sub": "12345"}'] }
         end
       end
     end
@@ -372,66 +370,6 @@ describe OmniAuth::Strategies::GoogleOauth2 do
 
         it 'should include raw_info' do
           expect(subject.extra[:raw_info]).to eq('sub' => '12345')
-        end
-      end
-    end
-
-    describe 'raw_friend_info' do
-      context 'when skip_info is true' do
-        before { subject.options[:skip_info] = true }
-
-        it 'should not include raw_friend_info' do
-          expect(subject.extra).not_to have_key(:raw_friend_info)
-        end
-      end
-
-      context 'when skip_info is false' do
-        before { subject.options[:skip_info] = false }
-
-        context 'when skip_friends is true' do
-          before { subject.options[:skip_friends] = true }
-
-          it 'should not include raw_friend_info' do
-            expect(subject.extra).not_to have_key(:raw_friend_info)
-          end
-        end
-
-        context 'when skip_friends is false' do
-          before { subject.options[:skip_friends] = false }
-
-          it 'should not include raw_friend_info' do
-            expect(subject.extra[:raw_friend_info]).to eq([{ 'foo' => 'bar' }])
-          end
-        end
-      end
-    end
-
-    describe 'raw_image_info' do
-      context 'when skip_info is true' do
-        before { subject.options[:skip_info] = true }
-
-        it 'should not include raw_image_info' do
-          expect(subject.extra).not_to have_key(:raw_image_info)
-        end
-      end
-
-      context 'when skip_info is false' do
-        before { subject.options[:skip_info] = false }
-
-        context 'when skip_image_info is true' do
-          before { subject.options[:skip_image_info] = true }
-
-          it 'should not include raw_image_info' do
-            expect(subject.extra).not_to have_key(:raw_image_info)
-          end
-        end
-
-        context 'when skip_image_info is false' do
-          before { subject.options[:skip_image_info] = false }
-
-          it 'should include raw_image_info' do
-            expect(subject.extra[:raw_image_info]).to eq('image' => 'imageData')
-          end
         end
       end
     end
@@ -679,7 +617,7 @@ describe OmniAuth::Strategies::GoogleOauth2 do
       OAuth2::Client.new('abc', 'def') do |builder|
         builder.request :url_encoded
         builder.adapter :test do |stub|
-          stub.get('/plus/v1/people/me/openIdConnect') do
+          stub.get('/oauth2/v3/userinfo') do
             [200, { 'Content-Type' => 'application/json; charset=UTF-8' }, JSON.dump(
               hd: 'example.com'
             )]
@@ -694,7 +632,7 @@ describe OmniAuth::Strategies::GoogleOauth2 do
         OAuth2::Client.new('abc', 'def') do |builder|
           builder.request :url_encoded
           builder.adapter :test do |stub|
-            stub.get('/plus/v1/people/me/openIdConnect') do
+            stub.get('/oauth2/v3/userinfo') do
               [200, { 'Content-Type' => 'application/json; charset=UTF-8' }, JSON.dump({})]
             end
           end


### PR DESCRIPTION
Should address the recent notice from Google+ that they're shutting down the API in 2019.

Issue described in #340

As a part of this change, I've removed the soon to be deprecated `raw_friend_info` and `raw_image_info` properties as these don't exist in a non-Google+ world.