### PR TITLE
Verify multiple Google issuers and fix JWT claim verifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ You can configure several options, which you pass in to the `provider` method vi
 
 * `openid_realm`: Set the OpenID realm value, to allow upgrading from OpenID based authentication to OAuth 2 based authentication. When this is set correctly an `openid_id` value will be set in `[:extra][:id_info]` in the authentication hash with the value of the user's OpenID ID URL.
 
-* `verify_iss`: Allows you to disable iss validation when decoding the JWT. This was added since Google now returns either `accounts.google.com` or `https://accounts.google.com`, and there is no way to predict what they will return, causing JWT validation failures.
+* `verify_iss`: Allows you to disable iss validation when decoding the JWT. This gem will attempt to verify the [issuer is either `accounts.google.com` or `https://accounts.google.com`](https://developers.google.com/identity/sign-in/web/backend-auth).
 
 Here's an example of a possible configuration where the strategy name is changed, the user is asked for extra permissions, the user is always prompted to select his account when logging in and the user's profile picture is returned as a thumbnail:
 

--- a/README.md
+++ b/README.md
@@ -87,8 +87,6 @@ You can configure several options, which you pass in to the `provider` method vi
 
 * `openid_realm`: Set the OpenID realm value, to allow upgrading from OpenID based authentication to OAuth 2 based authentication. When this is set correctly an `openid_id` value will be set in `[:extra][:id_info]` in the authentication hash with the value of the user's OpenID ID URL.
 
-* `verify_iss`: Allows you to disable iss validation when decoding the JWT. This gem will attempt to verify the [issuer is either `accounts.google.com` or `https://accounts.google.com`](https://developers.google.com/identity/sign-in/web/backend-auth).
-
 Here's an example of a possible configuration where the strategy name is changed, the user is asked for extra permissions, the user is always prompted to select his account when logging in and the user's profile picture is returned as a thumbnail:
 
 ```ruby

--- a/lib/omniauth/strategies/google_oauth2.rb
+++ b/lib/omniauth/strategies/google_oauth2.rb
@@ -20,7 +20,6 @@ module OmniAuth
       option :jwt_leeway, 60
       option :authorize_options, %i[access_type hd login_hint prompt request_visible_actions scope state redirect_uri include_granted_scopes openid_realm device_id device_name]
       option :authorized_client_ids, []
-      option :verify_iss, true
 
       option :client_options,
              site: 'https://oauth2.googleapis.com',

--- a/lib/omniauth/strategies/google_oauth2.rb
+++ b/lib/omniauth/strategies/google_oauth2.rb
@@ -8,6 +8,7 @@ module OmniAuth
   module Strategies
     # Main class for Google OAuth2 strategy.
     class GoogleOauth2 < OmniAuth::Strategies::OAuth2
+      ALLOWED_ISSUERS = ['accounts.google.com', 'https://accounts.google.com'].freeze
       BASE_SCOPE_URL = 'https://www.googleapis.com/auth/'
       BASE_SCOPES = %w[profile email openid].freeze
       DEFAULT_SCOPE = 'email,profile'
@@ -59,18 +60,23 @@ module OmniAuth
         hash = {}
         hash[:id_token] = access_token['id_token']
         if !options[:skip_jwt] && !access_token['id_token'].nil?
-          hash[:id_info] = ::JWT.decode(
-            access_token['id_token'], nil, false, verify_iss: options.verify_iss,
-                                                  iss: 'accounts.google.com',
-                                                  verify_aud: true,
-                                                  aud: options.client_id,
-                                                  verify_sub: false,
-                                                  verify_expiration: true,
-                                                  verify_not_before: true,
-                                                  verify_iat: true,
-                                                  verify_jti: false,
-                                                  leeway: options[:jwt_leeway]
-          ).first
+          decoded = ::JWT.decode(access_token['id_token'], nil, false).first
+
+          # We have to manually verify the claims because the third parameter to
+          # JWT.decode is false since no verification key is provided.
+          ::JWT::Verify.verify_claims(decoded,
+                                      verify_iss: true,
+                                      iss: ALLOWED_ISSUERS,
+                                      verify_aud: true,
+                                      aud: options.client_id,
+                                      verify_sub: false,
+                                      verify_expiration: true,
+                                      verify_not_before: true,
+                                      verify_iat: true,
+                                      verify_jti: false,
+                                      leeway: options[:jwt_leeway])
+
+          hash[:id_info] = decoded
         end
         hash[:raw_info] = raw_info unless skip_info?
         hash[:raw_friend_info] = raw_friend_info(raw_info['sub']) unless skip_info? || options[:skip_friends]

--- a/omniauth-google-oauth2.gemspec
+++ b/omniauth-google-oauth2.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 2.1'
 
-  gem.add_runtime_dependency 'jwt', '>= 1.5'
+  gem.add_runtime_dependency 'jwt', '>= 2.0'
   gem.add_runtime_dependency 'omniauth', '>= 1.1.1'
   gem.add_runtime_dependency 'omniauth-oauth2', '>= 1.5'
 

--- a/spec/omniauth/strategies/google_oauth2_spec.rb
+++ b/spec/omniauth/strategies/google_oauth2_spec.rb
@@ -624,37 +624,6 @@ describe OmniAuth::Strategies::GoogleOauth2 do
     end
   end
 
-  describe 'verify_iss option' do
-    before(:each) do
-      subject.options.client_options[:connection_build] = proc do |builder|
-        builder.request :url_encoded
-        builder.adapter :test do |stub|
-          stub.get('/oauth2/v3/tokeninfo?access_token=invalid_iss_token') do
-            [200, { 'Content-Type' => 'application/json; charset=UTF-8' },
-             JSON.dump(
-               aud: '000000000000.apps.googleusercontent.com',
-               sub: '123456789',
-               email_verified: 'true',
-               email: 'example@example.com',
-               access_type: 'offline',
-               scope: 'profile email',
-               expires_in: 436,
-               iss: 'foobar.com'
-             )]
-          end
-        end
-      end
-      subject.options.authorized_client_ids = ['000000000000.apps.googleusercontent.com']
-      subject.options.client_id = '000000000000.apps.googleusercontent.com'
-      subject.options[:verify_iss] = false
-    end
-
-    it 'should verify token if the iss does not match options.expected_iss' do
-      result = subject.send(:verify_token, 'invalid_iss_token')
-      expect(result).to eq(true)
-    end
-  end
-
   describe 'verify_token' do
     before(:each) do
       subject.options.client_options[:connection_build] = proc do |builder|


### PR DESCRIPTION
Per https://developers.google.com/identity/sign-in/web/backend-auth:

> The value of iss in the ID token is equal to accounts.google.com or https://accounts.google.com.

The JWT decoder **should** be verifying that the `iss` is either one of
those values. In ruby-jwt 1.5.6, only one issuer can be supplied
(https://github.com/jwt/ruby-jwt/blob/8e8a9c9f9fd455537c03b6dcde1e20ebbc1fe585/lib/jwt/verify.rb#L62).

However, in ruby-jwt v2.0+, this can be an array:
https://github.com/jwt/ruby-jwt/commit/ed3a6483b4e81314ca2e7168701a9d34afcb690d