### PR TITLE
Ensure `info[:email]` is always verified, and include `unverified_email`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,20 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 0.7.0 - 2019-06-03
+
+### Added
+- Ensure `info[:email]` is always verified, and include `unverified_email`
+
+### Deprecated
+- Nothing.
+
+### Removed
+- Nothing.
+
+### Fixed
+- Nothing.
+
 ## 0.6.1 - 2019-03-07
 
 ### Added

--- a/lib/omniauth/google_oauth2/version.rb
+++ b/lib/omniauth/google_oauth2/version.rb
@@ -2,6 +2,6 @@
 
 module OmniAuth
   module GoogleOauth2
-    VERSION = '0.6.1'
+    VERSION = '0.7.0'
   end
 end

--- a/lib/omniauth/strategies/google_oauth2.rb
+++ b/lib/omniauth/strategies/google_oauth2.rb
@@ -46,7 +46,8 @@ module OmniAuth
       info do
         prune!(
           name: raw_info['name'],
-          email: raw_info['email'],
+          email: verified_email,
+          unverified_email: raw_info['email'],
           email_verified: raw_info['email_verified'],
           first_name: raw_info['given_name'],
           last_name: raw_info['family_name'],
@@ -135,6 +136,10 @@ module OmniAuth
         scope_list = raw_scope.split(' ').map { |item| item.split(',') }.flatten
         scope_list.map! { |s| s =~ %r{^https?://} || BASE_SCOPES.include?(s) ? s : "#{BASE_SCOPE_URL}#{s}" }
         scope_list.join(' ')
+      end
+
+      def verified_email
+        raw_info['email_verified'] ? raw_info['email'] : nil
       end
 
       def get_token_options(redirect_uri)


### PR DESCRIPTION
This is a 'safe by default' replacement for efe0e901c030318f3285075e6bd454c75a0ea213 as discussed in #362. I have added a couple of specs which illustrate how it works.

@zquestz I have not yet included a changelog entry or version bump. Let me know if you would like these included in the PR.