### PR TITLE
Add filename for example controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,8 @@ devise :omniauthable, omniauth_providers: [:google_oauth2]
 Then make sure your callbacks controller is setup.
 
 ```ruby
+# app/controllers/users/omniauth_callbacks_controller.rb:
+
 class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   def google_oauth2
       # You need to implement the method below in your model (e.g. app/models/user.rb)


### PR DESCRIPTION
A friend was trying to set this up and is newer to Rails. Since this controller is namespaced, Rails has expectations about how it's named. I think the addition of the `/users/` part of the filename is helpful for people less familiar with namespaced filenames.