### PR TITLE
Explicitly declare direct dependency on OAuth2 gem

### DIFF
--- a/lib/omniauth/strategies/google_oauth2.rb
+++ b/lib/omniauth/strategies/google_oauth2.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'jwt'
+require 'oauth2'
 require 'omniauth/strategies/oauth2'
 require 'uri'
 

--- a/omniauth-google-oauth2.gemspec
+++ b/omniauth-google-oauth2.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = '>= 2.2'
 
   gem.add_runtime_dependency 'jwt', '>= 2.0'
+  gem.add_runtime_dependency 'oauth2', '~> 1.1'
   gem.add_runtime_dependency 'omniauth', '>= 1.1.1'
   gem.add_runtime_dependency 'omniauth-oauth2', '>= 1.6'
 


### PR DESCRIPTION
The current version of this gem [has a direct dependency on the `oauth2` gem](https://github.com/zquestz/omniauth-google-oauth2/blob/v0.8.0/lib/omniauth/strategies/google_oauth2.rb#L114). Even though the gem is loaded indirectly added through `omniauth-oauth2`, it's nice to explicitly declare it as a runtime dependency as well.

**Background:** I was debugging through this gem code and was confused about where the `::OAuth2` constant was coming from after not seeing it in the gemspec.