### PR TITLE
Do not verify iat claim for JWT

### DIFF
--- a/lib/omniauth/strategies/google_oauth2.rb
+++ b/lib/omniauth/strategies/google_oauth2.rb
@@ -75,7 +75,7 @@ module OmniAuth
                                       verify_sub: false,
                                       verify_expiration: true,
                                       verify_not_before: true,
-                                      verify_iat: true,
+                                      verify_iat: false,
                                       verify_jti: false,
                                       leeway: options[:jwt_leeway])
 


### PR DESCRIPTION
In https://github.com/jwt/ruby-jwt/commit/a1ede264b3ae0e3178686bcc4d2302983e566838,
ruby-jwt removed the ability to allow a leeway when verifying the iat claim.
That means that even tiny skew in server clocks can cause a JWT::InvalidIatError to be raised

According to the JWT specification at https://tools.ietf.org/html/rfc7519#section-4.1.6
the iat claim is not intended to be verified. If a JWT is only valid after
a certain time, the nbf (not before) claim will be used.