### PR TITLE
Constrain omniauth version

### DIFF
--- a/omniauth-google-oauth2.gemspec
+++ b/omniauth-google-oauth2.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency 'jwt', '>= 2.0'
   gem.add_runtime_dependency 'oauth2', '~> 1.1'
-  gem.add_runtime_dependency 'omniauth', '>= 1.1.1'
+  gem.add_runtime_dependency 'omniauth', '~> 1.1'
   gem.add_runtime_dependency 'omniauth-oauth2', '>= 1.6'
 
   gem.add_development_dependency 'rake', '~> 12.0'


### PR DESCRIPTION
Relates to issue #395 

* Omniauth v2 has been release recently and will be used per the gemspec. Doing this will cause an exception to raise in devise 4.7.3. The Omniauth version in the gemspec should be constrained so it does not install v2 until a new release of Devise comes out.