### PR TITLE
Enable bundler caching for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+cache: bundler
 rvm:
   - '2.3.4'
   - '2.4.1'


### PR DESCRIPTION
Would be interested to know why bundler caching of Travis hasn't been enabled in this repository. Thank you.