### PR TITLE
Allow for omniauth 2.0 series

### DIFF
--- a/lib/omniauth/strategies/google_oauth2.rb
+++ b/lib/omniauth/strategies/google_oauth2.rb
@@ -102,7 +102,7 @@ module OmniAuth
       private
 
       def callback_url
-        options[:redirect_uri] || (full_host + script_name + callback_path)
+        options[:redirect_uri] || (full_host + callback_path)
       end
 
       def get_access_token(request)

--- a/omniauth-google-oauth2.gemspec
+++ b/omniauth-google-oauth2.gemspec
@@ -22,8 +22,8 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency 'jwt', '>= 2.0'
   gem.add_runtime_dependency 'oauth2', '~> 1.1'
-  gem.add_runtime_dependency 'omniauth', '~> 1.1'
-  gem.add_runtime_dependency 'omniauth-oauth2', '>= 1.6'
+  gem.add_runtime_dependency 'omniauth', '~> 2.0'
+  gem.add_runtime_dependency 'omniauth-oauth2', '~> 1.7.1'
 
   gem.add_development_dependency 'rake', '~> 12.0'
   gem.add_development_dependency 'rspec', '~> 3.6'

--- a/spec/omniauth/strategies/google_oauth2_spec.rb
+++ b/spec/omniauth/strategies/google_oauth2_spec.rb
@@ -289,14 +289,27 @@ describe OmniAuth::Strategies::GoogleOauth2 do
     end
   end
 
-  describe '#callback_path' do
+  describe '#callback_url' do
+    let(:base_url) { 'https://example.com' }
+
     it 'has the correct default callback path' do
-      expect(subject.callback_path).to eq('/auth/google_oauth2/callback')
+      allow(subject).to receive(:full_host) { base_url }
+      allow(subject).to receive(:script_name) { '' }
+      expect(subject.send(:callback_url)).to eq(base_url + '/auth/google_oauth2/callback')
+    end
+
+    it 'should set the callback path with script_name if present' do
+      base_url = 'https://example.com'
+      allow(subject).to receive(:full_host) { base_url }
+      allow(subject).to receive(:script_name) { '/v1' }
+      expect(subject.send(:callback_url)).to eq(base_url + '/v1/auth/google_oauth2/callback')
     end
 
     it 'should set the callback_path parameter if present' do
       @options = { callback_path: '/auth/foo/callback' }
-      expect(subject.callback_path).to eq('/auth/foo/callback')
+      allow(subject).to receive(:full_host) { base_url }
+      allow(subject).to receive(:script_name) { '' }
+      expect(subject.send(:callback_url)).to eq(base_url + '/auth/foo/callback')
     end
   end
 

--- a/spec/omniauth/strategies/google_oauth2_spec.rb
+++ b/spec/omniauth/strategies/google_oauth2_spec.rb
@@ -299,7 +299,6 @@ describe OmniAuth::Strategies::GoogleOauth2 do
     end
 
     it 'should set the callback path with script_name if present' do
-      base_url = 'https://example.com'
       allow(subject).to receive(:full_host) { base_url }
       allow(subject).to receive(:script_name) { '/v1' }
       expect(subject.send(:callback_url)).to eq(base_url + '/v1/auth/google_oauth2/callback')


### PR DESCRIPTION
Hi, @zquestz 
related issue #401.

This PR allow for omniauth 2.0.
Could you review?

If you want to try my branch, you can use like following in Gemfile.
```rb
gem 'omniauth-google-oauth2', github: 'koshilife/omniauth-google-oauth2', branch: 'allow-for-omniauth-2.0'
```