### PR TITLE
Fix readme since Omniauth 2.0 requires post method

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,10 @@ end
 For your views you can login using:
 
 ```erb
+<%# omniauth-google-oauth2 1.0.0 uses OmniAuth 2 and requires using HTTP Post to initiate authentication: %>
+<%= link_to "Sign in with Google", user_google_oauth2_omniauth_authorize_path, method: :post %>
+
+<%# omniauth-google-oauth2 prior 1.0.0: %>
 <%= link_to "Sign in with Google", user_google_oauth2_omniauth_authorize_path %>
 
 <%# Devise prior 4.1.0: %>


### PR DESCRIPTION
Hi, @zquestz!
It looks like that since version 1.0.0 sign in links should use post method by default