### PR TITLE
Output granted scopes in credentials block of the auth hash

### DIFF
--- a/spec/omniauth/strategies/google_oauth2_spec.rb
+++ b/spec/omniauth/strategies/google_oauth2_spec.rb
@@ -347,6 +347,22 @@ describe OmniAuth::Strategies::GoogleOauth2 do
     end
   end
 
+  describe '#credentials' do
+    let(:client) { OAuth2::Client.new('abc', 'def') }
+    let(:access_token) { OAuth2::AccessToken.from_hash(client, access_token: 'valid_access_token', expires_at: 123_456_789, refresh_token: 'valid_refresh_token') }
+    before(:each) { allow(subject).to receive(:access_token).and_return(access_token) }
+
+    it 'should return access token and (optionally) refresh token' do
+      expect(subject.credentials.to_h).to \
+        match(hash_including(
+                'token' => 'valid_access_token',
+                'refresh_token' => 'valid_refresh_token',
+                'expires_at' => 123_456_789,
+                'expires' => true
+              ))
+    end
+  end
+
   describe '#extra' do
     let(:client) do
       OAuth2::Client.new('abc', 'def') do |builder|


### PR DESCRIPTION
Google recommends to use [Incremental authorization](https://developers.google.com/identity/protocols/oauth2/web-server#incrementalAuth) and request scopes only when needed. And there is `include_granted_scopes` option to enable this mode. And it works nice!

However, now it is hard to figure out whether user already has been granted required scopes or not yet, because there is no information about it in the auth hash. In this pull request I'm trying to solve this problem.

Luckily, there is API for that: [`tokeninfo` endpoint](https://developers.google.com/identity/sign-in/web/backend-auth#calling-the-tokeninfo-endpoint) (however `scope` isn't documented here, but [documented in NodeJS API](https://googleapis.dev/nodejs/googleapis/latest/oauth2/interfaces/Schema$Tokeninfo.html#scope), I found info about it [here](https://community.auth0.com/t/how-do-i-retrieve-the-granted-scopes-provided-by-google/42598/3) and in my experiments it always return list of granted scopes even if token was acquired without using `include_granted_scopes`). And more luckily, omniauth-google-oauth2 is already using it for token validation!

So I added spec for `credentials` section of Auth hash (there wasn't one) and added output `scope` there as it is present in `tokeninfo` output.