### PR TITLE
Add option to restrict overriding authorize_options by user request

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ You can configure several options, which you pass in to the `provider` method vi
 
 * `provider_ignores_state`: You will need to set this to `true` when using the `One-time Code Flow` below. In this flow there is no server side redirect that would set the state.
 
+* `overridable_authorize_options`: By default, all `authorize_options` can be overridden with request parameters. You can restrict the behavior by using this option.
+
 Here's an example of a possible configuration where the strategy name is changed, the user is asked for extra permissions, the user is always prompted to select their account when logging in and the user's profile picture is returned as a thumbnail:
 
 ```ruby

--- a/lib/omniauth/strategies/google_oauth2.rb
+++ b/lib/omniauth/strategies/google_oauth2.rb
@@ -15,13 +15,15 @@ module OmniAuth
       DEFAULT_SCOPE = 'email,profile'
       USER_INFO_URL = 'https://www.googleapis.com/oauth2/v3/userinfo'
       IMAGE_SIZE_REGEXP = /(s\d+(-c)?)|(w\d+-h\d+(-c)?)|(w\d+(-c)?)|(h\d+(-c)?)|c/
+      AUTHORIZE_OPTIONS = %i[access_type hd login_hint prompt request_visible_actions scope state redirect_uri include_granted_scopes openid_realm device_id device_name]
 
       option :name, 'google_oauth2'
       option :skip_friends, true
       option :skip_image_info, true
       option :skip_jwt, false
       option :jwt_leeway, 60
-      option :authorize_options, %i[access_type hd login_hint prompt request_visible_actions scope state redirect_uri include_granted_scopes openid_realm device_id device_name]
+      option :authorize_options, AUTHORIZE_OPTIONS
+      option :overridable_authorize_options, AUTHORIZE_OPTIONS
       option :authorized_client_ids, []
 
       option :client_options,
@@ -31,7 +33,7 @@ module OmniAuth
 
       def authorize_params
         super.tap do |params|
-          options[:authorize_options].each do |k|
+          (options[:authorize_options] & options[:overridable_authorize_options]).each do |k|
             params[k] = request.params[k.to_s] unless [nil, ''].include?(request.params[k.to_s])
           end
 

--- a/spec/omniauth/strategies/google_oauth2_spec.rb
+++ b/spec/omniauth/strategies/google_oauth2_spec.rb
@@ -242,9 +242,18 @@ describe OmniAuth::Strategies::GoogleOauth2 do
           context "authorize option #{k}" do
             let(:request) { double('Request', params: { k.to_s => 'http://example.com' }, cookies: {}, env: {}) }
 
-            it "should set the #{k} authorize option dynamically in the request" do
-              @options = { k: '' }
-              expect(subject.authorize_params[k.to_s]).to eq('http://example.com')
+            context 'when overridable_authorize_options is default' do
+              it "should set the #{k} authorize option dynamically in the request" do
+                @options = { k: '' }
+                expect(subject.authorize_params[k.to_s]).to eq('http://example.com')
+              end
+            end
+
+            context 'when overridable_authorize_options is empty' do
+              it "should not set the #{k} authorize option dynamically in the request" do
+                @options = { k: '', overridable_authorize_options: [] }
+                expect(subject.authorize_params[k.to_s]).not_to eq('http://example.com')
+              end
             end
           end
         end
@@ -252,9 +261,18 @@ describe OmniAuth::Strategies::GoogleOauth2 do
         describe 'custom authorize_options' do
           let(:request) { double('Request', params: { 'foo' => 'something' }, cookies: {}, env: {}) }
 
-          it 'should support request overrides from custom authorize_options' do
-            @options = { authorize_options: [:foo], foo: '' }
-            expect(subject.authorize_params['foo']).to eq('something')
+          context 'when overridable_authorize_options is default' do
+            it 'should not support request overrides from custom authorize_options' do
+              @options = { authorize_options: [:foo], foo: '' }
+              expect(subject.authorize_params['foo']).not_to eq('something')
+            end
+          end
+
+          context 'when overridable_authorize_options is customized' do
+            it 'should support request overrides from custom authorize_options' do
+              @options = { authorize_options: [:foo], overridable_authorize_options: [:foo], foo: '' }
+              expect(subject.authorize_params['foo']).to eq('something')
+            end
           end
         end
       end


### PR DESCRIPTION
Thank you for the great gem!

By the following implementation, all authorize_options can be overridden with request parameters.

https://github.com/zquestz/omniauth-google-oauth2/blob/8bebf08bcce88a4dc3e59111eb97785b166828e8/lib/omniauth/strategies/google_oauth2.rb#L34-L36

For example, even if we restrict it with `hd: 'exanple.com'`, end-users can use any `hd` with ` /oauth/google_oauth2?hd=example.net`.
It's flexible and convenient, but it may be unexpected behavior in some apps.

I have added an option to control this behavior with this pull request.
If you don't need this change, feel free to close it.

Thanks,