### PR TITLE
Allow oauth2 gem to be upgraded until 2.0.4

### DIFF
--- a/omniauth-google-oauth2.gemspec
+++ b/omniauth-google-oauth2.gemspec
@@ -9,8 +9,8 @@ Gem::Specification.new do |gem|
   gem.name          = 'omniauth-google-oauth2'
   gem.version       = OmniAuth::GoogleOauth2::VERSION
   gem.license       = 'MIT'
-  gem.summary       = %(A Google OAuth2 strategy for OmniAuth 1.x)
-  gem.description   = %(A Google OAuth2 strategy for OmniAuth 1.x. This allows you to login to Google with your ruby app.)
+  gem.summary       = %(A Google OAuth2 strategy for OmniAuth 2.x)
+  gem.description   = %(A Google OAuth2 strategy for OmniAuth 2.x. This allows you to login to Google with your ruby app.)
   gem.authors       = ['Josh Ellithorpe', 'Yury Korolev']
   gem.email         = ['quest@mac.com']
   gem.homepage      = 'https://github.com/zquestz/omniauth-google-oauth2'
@@ -18,12 +18,12 @@ Gem::Specification.new do |gem|
   gem.files         = `git ls-files`.split("\n")
   gem.require_paths = ['lib']
 
-  gem.required_ruby_version = '>= 2.2'
+  gem.required_ruby_version = '>= 2.7'
 
   gem.add_runtime_dependency 'jwt', '>= 2.0'
-  gem.add_runtime_dependency 'oauth2', '~> 1.1'
+  gem.add_runtime_dependency 'oauth2', '<= 2.0.4'
   gem.add_runtime_dependency 'omniauth', '~> 2.0'
-  gem.add_runtime_dependency 'omniauth-oauth2', '~> 1.7.1'
+  gem.add_runtime_dependency 'omniauth-oauth2', '~> 1.8.0'
 
   gem.add_development_dependency 'rake', '~> 12.0'
   gem.add_development_dependency 'rspec', '~> 3.6'


### PR DESCRIPTION
This allows you to upgrade the oauth2 gem so we can use versions up to and including 2.0.4. I couldn't figure out how to get the tests to pass for going up to the latest because of something to do with the [changes in 2.0.5](https://github.com/oauth-xx/oauth2/blob/master/CHANGELOG.md#205---2022-07-07). This should address #425.