### PR TITLE
Support oauth2 v2.0.6+

### DIFF
--- a/lib/omniauth/strategies/google_oauth2.rb
+++ b/lib/omniauth/strategies/google_oauth2.rb
@@ -67,9 +67,9 @@ module OmniAuth
 
       extra do
         hash = {}
-        hash[:id_token] = access_token['id_token']
-        if !options[:skip_jwt] && !access_token['id_token'].nil?
-          decoded = ::JWT.decode(access_token['id_token'], nil, false).first
+        hash[:id_token] = access_token.token
+        if !options[:skip_jwt] && !nil_or_empty(access_token.token)
+          decoded = ::JWT.decode(access_token.token, nil, false).first
 
           # We have to manually verify the claims because the third parameter to
           # JWT.decode is false since no verification key is provided.
@@ -105,6 +105,10 @@ module OmniAuth
       alias build_access_token custom_build_access_token
 
       private
+
+      def nil_or_empty(obj)
+        obj.is_a?(String) ? obj.empty? : obj.nil?
+      end
 
       def callback_url
         options[:redirect_uri] || (full_host + callback_path)

--- a/omniauth-google-oauth2.gemspec
+++ b/omniauth-google-oauth2.gemspec
@@ -9,8 +9,8 @@ Gem::Specification.new do |gem|
   gem.name          = 'omniauth-google-oauth2'
   gem.version       = OmniAuth::GoogleOauth2::VERSION
   gem.license       = 'MIT'
-  gem.summary       = %(A Google OAuth2 strategy for OmniAuth 1.x)
-  gem.description   = %(A Google OAuth2 strategy for OmniAuth 1.x. This allows you to login to Google with your ruby app.)
+  gem.summary       = %(A Google OAuth2 strategy for OmniAuth 2.x)
+  gem.description   = %(A Google OAuth2 strategy for OmniAuth 2.x. This allows you to login to Google with your ruby app.)
   gem.authors       = ['Josh Ellithorpe', 'Yury Korolev']
   gem.email         = ['quest@mac.com']
   gem.homepage      = 'https://github.com/zquestz/omniauth-google-oauth2'
@@ -21,9 +21,9 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = '>= 2.2'
 
   gem.add_runtime_dependency 'jwt', '>= 2.0'
-  gem.add_runtime_dependency 'oauth2', '~> 1.1'
+  gem.add_runtime_dependency 'oauth2', '<= 2.0.4'
   gem.add_runtime_dependency 'omniauth', '~> 2.0'
-  gem.add_runtime_dependency 'omniauth-oauth2', '~> 1.7.1'
+  gem.add_runtime_dependency 'omniauth-oauth2', '~> 1.8.0'
 
   gem.add_development_dependency 'rake', '~> 12.0'
   gem.add_development_dependency 'rspec', '~> 3.6'

--- a/omniauth-google-oauth2.gemspec
+++ b/omniauth-google-oauth2.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = '>= 2.2'
 
   gem.add_runtime_dependency 'jwt', '>= 2.0'
-  gem.add_runtime_dependency 'oauth2', '<= 2.0.4'
+  gem.add_runtime_dependency 'oauth2', '~> 2.0.5'
   gem.add_runtime_dependency 'omniauth', '~> 2.0'
   gem.add_runtime_dependency 'omniauth-oauth2', '~> 1.8.0'
 

--- a/omniauth-google-oauth2.gemspec
+++ b/omniauth-google-oauth2.gemspec
@@ -9,8 +9,8 @@ Gem::Specification.new do |gem|
   gem.name          = 'omniauth-google-oauth2'
   gem.version       = OmniAuth::GoogleOauth2::VERSION
   gem.license       = 'MIT'
-  gem.summary       = %(A Google OAuth2 strategy for OmniAuth 2.x)
-  gem.description   = %(A Google OAuth2 strategy for OmniAuth 2.x. This allows you to login to Google with your ruby app.)
+  gem.summary       = %(A Google OAuth2 strategy for OmniAuth 1.x)
+  gem.description   = %(A Google OAuth2 strategy for OmniAuth 1.x. This allows you to login to Google with your ruby app.)
   gem.authors       = ['Josh Ellithorpe', 'Yury Korolev']
   gem.email         = ['quest@mac.com']
   gem.homepage      = 'https://github.com/zquestz/omniauth-google-oauth2'

--- a/omniauth-google-oauth2.gemspec
+++ b/omniauth-google-oauth2.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = '>= 2.2'
 
   gem.add_runtime_dependency 'jwt', '>= 2.0'
-  gem.add_runtime_dependency 'oauth2', '~> 2.0.5'
+  gem.add_runtime_dependency 'oauth2', '~> 2.0.6'
   gem.add_runtime_dependency 'omniauth', '~> 2.0'
   gem.add_runtime_dependency 'omniauth-oauth2', '~> 1.8.0'
 

--- a/spec/omniauth/strategies/google_oauth2_spec.rb
+++ b/spec/omniauth/strategies/google_oauth2_spec.rb
@@ -321,7 +321,7 @@ describe OmniAuth::Strategies::GoogleOauth2 do
         end
       end
     end
-    let(:access_token) { OAuth2::AccessToken.from_hash(client, {}) }
+    let(:access_token) { OAuth2::AccessToken.from_hash(client, { 'access_token' => 'a' }) }
     before { allow(subject).to receive(:access_token).and_return(access_token) }
 
     context 'with verified email' do
@@ -387,8 +387,6 @@ describe OmniAuth::Strategies::GoogleOauth2 do
         end
       end
     end
-    let(:access_token) { OAuth2::AccessToken.from_hash(client, {}) }
-
     before { allow(subject).to receive(:access_token).and_return(access_token) }
 
     describe 'id_token' do
@@ -449,7 +447,18 @@ describe OmniAuth::Strategies::GoogleOauth2 do
         end
       end
 
-      context 'when the id_token is missing' do
+      context 'when the access token is empty or nil' do
+        let(:client) do
+          OAuth2::Client.new('abc', 'def', { raise_errors: false }) do |builder|
+            builder.request :url_encoded
+            builder.adapter :test do |stub|
+              stub.get('/oauth2/v3/userinfo') { [200, { 'content-type' => 'application/json' }, '{"sub": "12345"}'] }
+            end
+          end
+        end
+        let(:access_token) { OAuth2::AccessToken.new(client, nil) }
+        before { allow(subject.extra).to receive(:access_token).and_return(access_token) }
+
         it 'should not include id_token' do
           expect(subject.extra).not_to have_key(:id_token)
         end
@@ -461,6 +470,19 @@ describe OmniAuth::Strategies::GoogleOauth2 do
     end
 
     describe 'raw_info' do
+      let(:token_info) do
+        {
+          'abc' => 'xyz',
+          'exp' => Time.now.to_i + 3600,
+          'nbf' => Time.now.to_i - 60,
+          'iat' => Time.now.to_i,
+          'aud' => 'appid',
+          'iss' => 'accounts.google.com'
+        }
+      end
+      let(:id_token) { JWT.encode(token_info, 'secret') }
+      let(:access_token) { OAuth2::AccessToken.from_hash(client, 'id_token' => id_token) }
+
       context 'when skip_info is true' do
         before { subject.options[:skip_info] = true }
 
@@ -644,16 +666,25 @@ describe OmniAuth::Strategies::GoogleOauth2 do
       subject.build_access_token
     end
 
+    let(:client) do
+      OAuth2::Client.new('abc', 'def', { raise_errors: false }) do |builder|
+        builder.request :url_encoded
+        builder.adapter :test do |stub|
+          stub.get('/oauth2/v3/userinfo') { [200, { 'content-type' => 'application/json' }, '{"sub": "12345"}'] }
+        end
+      end
+    end
+
     it 'should read access_token from hash if this is not an AJAX request with a code parameter' do
       allow(request).to receive(:xhr?).and_return(false)
       allow(request).to receive(:params).and_return('access_token' => 'valid_access_token')
       expect(subject).to receive(:verify_token).with('valid_access_token').and_return true
-      expect(subject).to receive(:client).and_return(:client)
+      expect(subject).to receive(:client).and_return(client)
 
       token = subject.build_access_token
       expect(token).to be_instance_of(::OAuth2::AccessToken)
       expect(token.token).to eq('valid_access_token')
-      expect(token.client).to eq(:client)
+      expect(token.client).to eq(client)
     end
 
     it 'reads the code from a json request body' do
@@ -688,20 +719,29 @@ describe OmniAuth::Strategies::GoogleOauth2 do
       subject.build_access_token
     end
 
+    let(:client) do
+      OAuth2::Client.new('abc', 'def', { raise_errors: false }) do |builder|
+        builder.request :url_encoded
+        builder.adapter :test do |stub|
+          stub.get('/oauth2/v3/userinfo') { [200, { 'content-type' => 'application/json' }, '{"sub": "12345"}'] }
+        end
+      end
+    end
+
     it 'reads the access token from a json request body' do
       body = StringIO.new(%({"access_token":"valid_access_token"}))
 
       allow(request).to receive(:xhr?).and_return(false)
       allow(request).to receive(:content_type).and_return('application/json')
       allow(request).to receive(:body).and_return(body)
-      expect(subject).to receive(:client).and_return(:client)
+      expect(subject).to receive(:client).and_return(client)
 
       expect(subject).to receive(:verify_token).with('valid_access_token').and_return true
 
       token = subject.build_access_token
       expect(token).to be_instance_of(::OAuth2::AccessToken)
       expect(token.token).to eq('valid_access_token')
-      expect(token.client).to eq(:client)
+      expect(token.client).to eq(client)
     end
 
     it 'should use callback_url without query_string if this is not an AJAX request' do
@@ -777,7 +817,7 @@ describe OmniAuth::Strategies::GoogleOauth2 do
         end
       end
     end
-    let(:access_token) { OAuth2::AccessToken.from_hash(client, {}) }
+    let(:access_token) { OAuth2::AccessToken.from_hash(client, { 'access_token' => 'foo' }) }
 
     context 'when domain is nil' do
       let(:client) do

--- a/spec/omniauth/strategies/google_oauth2_spec.rb
+++ b/spec/omniauth/strategies/google_oauth2_spec.rb
@@ -658,16 +658,14 @@ describe OmniAuth::Strategies::GoogleOauth2 do
       subject.build_access_token
     end
 
-    let(:client) do
-      OAuth2::Client.new('abc', 'def') do |builder|
+    it 'should read access_token from hash if this is not an AJAX request with a code parameter' do
+      client = OAuth2::Client.new('abc', 'def') do |builder|
         builder.request :url_encoded
         builder.adapter :test do |stub|
           stub.get('/oauth2/v3/userinfo') { [200, { 'content-type' => 'application/json' }, '{"sub": "12345"}'] }
         end
       end
-    end
 
-    it 'should read access_token from hash if this is not an AJAX request with a code parameter' do
       allow(request).to receive(:xhr?).and_return(false)
       allow(request).to receive(:params).and_return('access_token' => 'valid_access_token')
       expect(subject).to receive(:verify_token).with('valid_access_token').and_return true
@@ -711,17 +709,14 @@ describe OmniAuth::Strategies::GoogleOauth2 do
       subject.build_access_token
     end
 
-    let(:client) do
-      OAuth2::Client.new('abc', 'def') do |builder|
+    it 'reads the access token from a json request body' do
+      body = StringIO.new(%({"access_token":"valid_access_token"}))
+      client = OAuth2::Client.new('abc', 'def') do |builder|
         builder.request :url_encoded
         builder.adapter :test do |stub|
           stub.get('/oauth2/v3/userinfo') { [200, { 'content-type' => 'application/json' }, '{"sub": "12345"}'] }
         end
       end
-    end
-
-    it 'reads the access token from a json request body' do
-      body = StringIO.new(%({"access_token":"valid_access_token"}))
 
       allow(request).to receive(:xhr?).and_return(false)
       allow(request).to receive(:content_type).and_return('application/json')

--- a/spec/omniauth/strategies/google_oauth2_spec.rb
+++ b/spec/omniauth/strategies/google_oauth2_spec.rb
@@ -659,7 +659,7 @@ describe OmniAuth::Strategies::GoogleOauth2 do
     end
 
     let(:client) do
-      OAuth2::Client.new('abc', 'def', { raise_errors: false }) do |builder|
+      OAuth2::Client.new('abc', 'def') do |builder|
         builder.request :url_encoded
         builder.adapter :test do |stub|
           stub.get('/oauth2/v3/userinfo') { [200, { 'content-type' => 'application/json' }, '{"sub": "12345"}'] }
@@ -712,7 +712,7 @@ describe OmniAuth::Strategies::GoogleOauth2 do
     end
 
     let(:client) do
-      OAuth2::Client.new('abc', 'def', { raise_errors: false }) do |builder|
+      OAuth2::Client.new('abc', 'def') do |builder|
         builder.request :url_encoded
         builder.adapter :test do |stub|
           stub.get('/oauth2/v3/userinfo') { [200, { 'content-type' => 'application/json' }, '{"sub": "12345"}'] }

--- a/spec/omniauth/strategies/google_oauth2_spec.rb
+++ b/spec/omniauth/strategies/google_oauth2_spec.rb
@@ -448,14 +448,6 @@ describe OmniAuth::Strategies::GoogleOauth2 do
       end
 
       context 'when the access token is empty or nil' do
-        let(:client) do
-          OAuth2::Client.new('abc', 'def') do |builder|
-            builder.request :url_encoded
-            builder.adapter :test do |stub|
-              stub.get('/oauth2/v3/userinfo') { [200, { 'content-type' => 'application/json' }, '{"sub": "12345"}'] }
-            end
-          end
-        end
         let(:access_token) { OAuth2::AccessToken.new(client, nil, { 'refresh_token' => 'foo' }) }
         before { allow(subject.extra).to receive(:access_token).and_return(access_token) }
 

--- a/spec/omniauth/strategies/google_oauth2_spec.rb
+++ b/spec/omniauth/strategies/google_oauth2_spec.rb
@@ -449,14 +449,14 @@ describe OmniAuth::Strategies::GoogleOauth2 do
 
       context 'when the access token is empty or nil' do
         let(:client) do
-          OAuth2::Client.new('abc', 'def', { raise_errors: false }) do |builder|
+          OAuth2::Client.new('abc', 'def') do |builder|
             builder.request :url_encoded
             builder.adapter :test do |stub|
               stub.get('/oauth2/v3/userinfo') { [200, { 'content-type' => 'application/json' }, '{"sub": "12345"}'] }
             end
           end
         end
-        let(:access_token) { OAuth2::AccessToken.new(client, nil) }
+        let(:access_token) { OAuth2::AccessToken.new(client, nil, { 'refresh_token' => 'foo' }) }
         before { allow(subject.extra).to receive(:access_token).and_return(access_token) }
 
         it 'should not include id_token' do


### PR DESCRIPTION
Solves issue #425 to provide complete support for latest version v2.0.6+
_!! Breaking changes for OAuth2 versions <2.0.6_

### Reasons for changes
---
OAuth2 v2.0.5 introduced a [breaking change](https://github.com/oauth-xx/oauth2/blob/master/CHANGELOG.md#206---2022-07-13). 
addressed with the following changes:
```ruby
# ./lib/omniauth/strategies/google-oauth2.rb
hash[:id_token] = access_token.token
if !options[:skip_jwt] && !nil_or_empty(access_token.token)
  decoded = ::JWT.decode(access_token.token, nil, false).first

#  Initializing AccessToken with nil id_token, using workaround or v2.0.6+, returns empty string instead of nil
def nil_or_empty(obj)
  obj.is_a?(String) ? obj.empty? : obj.nil?
end
```
> NOTE: I'm not certain if there are edge cases where access_token.token may still return nil, given the changes to oauth2, so nil_or_empty handles checking for both.

As well as a regression that prevents initializing AccessToken without 'id_token':
```ruby
# oauth2/lib/oauth2/access_token.rb v2.0.5
if @client.options[:raise_errors] && (@token.nil? || @token.empty?)
  error = Error.new(opts)
  raise(error)
end
```

Fixed for refresh_token work flows in v2.0.6:
```ruby
# oauth2/lib/oauth2/access_token.rb v.2.0.6
no_tokens = (@token.nil? || @token.empty?) && (@refresh_token.nil? || @refresh_token.empty?)
if no_tokens
  if @client.options[:raise_errors]
    error = Error.new(opts)
    raise(error)
  else
    warn('OAuth2::AccessToken has no token')
  end
end
```

This code led to multiple test failures that required the following changes:

- tests using OAuth2::AccessToken.from_hash() now include access_token
- tests using OAuth2::AccessToken.new() now include refresh_token
- OAuth2::AccessToken.from_hash() now require client.options method, so tests for methods that call from_hash() now create a OAuth2::Client object instead of a symbol

I am open to and appreciate any feedback on the changes.
