### PR TITLE
Add support for enable_granular_consent option

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ You can configure several options, which you pass in to the `provider` method vi
 
 * `include_granted_scopes`: If this is provided with the value true, and the authorization request is granted, the authorization will include any previous authorizations granted to this user/application combination for other scopes. See Google's [Incremental Authorization](https://developers.google.com/accounts/docs/OAuth2WebServer#incrementalAuth) for additional details.
 
+* `enable_granular_consent`: If this is provided with the value true, users can choose to only grant access to specific data. See Google's [How to handle granular permissions](https://developers.google.com/identity/protocols/oauth2/resources/granular-permissions) guide for additional details.
+
 * `openid_realm`: Set the OpenID realm value, to allow upgrading from OpenID based authentication to OAuth 2 based authentication. When this is set correctly an `openid_id` value will be set in `['extra']['id_info']` in the authentication hash with the value of the user's OpenID ID URL.
 
 * `provider_ignores_state`: You will need to set this to `true` when using the `One-time Code Flow` below. In this flow there is no server side redirect that would set the state.

--- a/lib/omniauth/strategies/google_oauth2.rb
+++ b/lib/omniauth/strategies/google_oauth2.rb
@@ -15,7 +15,7 @@ module OmniAuth
       DEFAULT_SCOPE = 'email,profile'
       USER_INFO_URL = 'https://www.googleapis.com/oauth2/v3/userinfo'
       IMAGE_SIZE_REGEXP = /(s\d+(-c)?)|(w\d+-h\d+(-c)?)|(w\d+(-c)?)|(h\d+(-c)?)|c/
-      AUTHORIZE_OPTIONS = %i[access_type hd login_hint prompt request_visible_actions scope state redirect_uri include_granted_scopes openid_realm device_id device_name]
+      AUTHORIZE_OPTIONS = %i[access_type hd login_hint prompt request_visible_actions scope state redirect_uri include_granted_scopes enable_granular_consent openid_realm device_id device_name]
 
       option :name, 'google_oauth2'
       option :skip_friends, true

--- a/spec/omniauth/strategies/google_oauth2_spec.rb
+++ b/spec/omniauth/strategies/google_oauth2_spec.rb
@@ -176,6 +176,17 @@ describe OmniAuth::Strategies::GoogleOauth2 do
       end
     end
 
+    describe 'enable_granular_consent' do
+      it 'should default to nil' do
+        expect(subject.authorize_params['enable_granular_consent']).to eq(nil)
+      end
+
+      it 'should set the enable_granular_consent parameter if present' do
+        @options = { enable_granular_consent: 'true' }
+        expect(subject.authorize_params['enable_granular_consent']).to eq('true')
+      end
+    end
+
     describe 'scope' do
       it 'should expand scope shortcuts' do
         @options = { scope: 'calendar' }


### PR DESCRIPTION
Starting June 17, 2024, Google will enable [granular consent](https://developers.google.com/identity/protocols/oauth2/resources/granular-permissions), which allows OAuth users to grant or deny Google account data permissions on a more granular level to third parties. 

To enable this feature right now, the `enable_granular_consent` parameter must be passed.

This PR adds support for this parameter.