### PR TITLE
POST to https://www.googleapis.com/oauth2/v3/tokeninfo intead of GET

### DIFF
--- a/lib/omniauth/strategies/google_oauth2.rb
+++ b/lib/omniauth/strategies/google_oauth2.rb
@@ -231,7 +231,7 @@ module OmniAuth
         return nil unless access_token
 
         @token_info ||= Hash.new do |h, k|
-          h[k] = client.request(:get, 'https://www.googleapis.com/oauth2/v3/tokeninfo', params: { access_token: access_token }).parsed
+          h[k] = client.request(:post, 'https://www.googleapis.com/oauth2/v3/tokeninfo', body: { access_token: access_token }).parsed
         end
 
         @token_info[access_token]

--- a/spec/omniauth/strategies/google_oauth2_spec.rb
+++ b/spec/omniauth/strategies/google_oauth2_spec.rb
@@ -384,7 +384,7 @@ describe OmniAuth::Strategies::GoogleOauth2 do
       subject.options.client_options[:connection_build] = proc do |builder|
         builder.request :url_encoded
         builder.adapter :test do |stub|
-          stub.get('/oauth2/v3/tokeninfo?access_token=valid_access_token') do
+          stub.post('/oauth2/v3/tokeninfo', 'access_token=valid_access_token') do
             [200, { 'Content-Type' => 'application/json; charset=UTF-8' }, JSON.dump(
               aud: '000000000000.apps.googleusercontent.com',
               sub: '123456789',
@@ -781,7 +781,7 @@ describe OmniAuth::Strategies::GoogleOauth2 do
       subject.options.client_options[:connection_build] = proc do |builder|
         builder.request :url_encoded
         builder.adapter :test do |stub|
-          stub.get('/oauth2/v3/tokeninfo?access_token=valid_access_token') do
+          stub.post('/oauth2/v3/tokeninfo', 'access_token=valid_access_token') do
             [200, { 'Content-Type' => 'application/json; charset=UTF-8' }, JSON.dump(
               aud: '000000000000.apps.googleusercontent.com',
               sub: '123456789',
@@ -792,7 +792,7 @@ describe OmniAuth::Strategies::GoogleOauth2 do
               expires_in: 436
             )]
           end
-          stub.get('/oauth2/v3/tokeninfo?access_token=invalid_access_token') do
+          stub.post('/oauth2/v3/tokeninfo', 'access_token=invalid_access_token') do
             [400, { 'Content-Type' => 'application/json; charset=UTF-8' }, JSON.dump(error_description: 'Invalid Value')]
           end
         end


### PR DESCRIPTION
To avoid leaking access tokens in logs or traces from the client application.

I struggled to find specific documentation that this endpoint (https://www.googleapis.com/oauth2/v3/tokeninfo) can receive GET and POST, if anyone knows where to find API docs for these endpoints that would be assuring.

I've lightly tested the fork in my own organisation and it appears to work as expected. I verified the change by using application traces which record metadata about HTTP requests made and I saw the expected change and no more leakage of the access token.

Before:
<img width="749" alt="image" src="https://github.com/zquestz/omniauth-google-oauth2/assets/42919858/2590c536-e672-4daa-ab2e-d863e325212e">


After:
<img width="568" alt="image" src="https://github.com/zquestz/omniauth-google-oauth2/assets/42919858/37c1ef65-7022-4b66-82b6-ef84a6e5a812">
