### PR TITLE
Use jwt v2.9.2's public claims verification API

### DIFF
--- a/lib/omniauth/strategies/google_oauth2.rb
+++ b/lib/omniauth/strategies/google_oauth2.rb
@@ -76,17 +76,11 @@ module OmniAuth
 
           # We have to manually verify the claims because the third parameter to
           # JWT.decode is false since no verification key is provided.
-          ::JWT::Claims.verify!(decoded,
-                                verify_iss: true,
-                                iss: ALLOWED_ISSUERS,
-                                verify_aud: true,
-                                aud: options.client_id,
-                                verify_sub: false,
-                                verify_expiration: true,
-                                verify_not_before: true,
-                                verify_iat: false,
-                                verify_jti: false,
-                                leeway: options[:jwt_leeway])
+          ::JWT::Claims.verify_payload!(decoded,
+                                        iss: ALLOWED_ISSUERS,
+                                        aud: options.client_id,
+                                        exp: { leeway: options.jwt_leeway },
+                                        nbf: { leeway: options.jwt_leeway })
 
           hash[:id_info] = decoded
         end

--- a/omniauth-google-oauth2.gemspec
+++ b/omniauth-google-oauth2.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 2.5'
 
-  gem.add_runtime_dependency 'jwt', '>= 2.9'
+  gem.add_runtime_dependency 'jwt', '>= 2.9.2'
   gem.add_runtime_dependency 'oauth2', '~> 2.0'
   gem.add_runtime_dependency 'omniauth', '~> 2.0'
   gem.add_runtime_dependency 'omniauth-oauth2', '~> 1.8'


### PR DESCRIPTION
This is a continuation of #464, which fixed backward compatibility with jwt v2.9.0 and v2.9.1.  v2.9.2 brought back the removed APIs, for backward compatibility, but marked them as internal only and/or deprecated.

For context, see the discussion here:
* https://github.com/jwt/ruby-jwt/issues/623
* https://github.com/jwt/ruby-jwt/pull/626