### PR TITLE
chore(doc): update JavaScript example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ const handleGoogleOauthSignIn = () => {
   // Parameters to pass to OAuth 2.0 endpoint.
   const params = new URLSearchParams({
     client_id: YOUR_CLIENT_ID,
-    prompt: 'select_account'
+    prompt: 'select_account',
     redirect_uri: YOUR_REDIRECT_URI, // This redirect_uri needs to redirect to the same domain as the one where this request is made from.
     response_type: 'code',
     scope: 'email openid profile',

--- a/examples/Gemfile
+++ b/examples/Gemfile
@@ -3,6 +3,7 @@
 source 'https://rubygems.org'
 
 gem 'omniauth-google-oauth2', path: '..'
+gem 'rackup'
 gem 'rubocop'
 gem 'sinatra'
 gem 'webrick'


### PR DESCRIPTION
closes https://github.com/zquestz/omniauth-google-oauth2/issues/450

## Summary
Noticed that you were looking for someone to update the JavaScript example in the README so as our team as been using the `omniahth-google-oauth2` gem for some time with a API only Rails app and it's been working fine for us since then I figured I might as well share our way of doing it.

I removed the "Getting around the `redirect_uri_mismatch` error" section because I specify why the `redirect_uri_mismatch` error might happen in my example and how to prevent it from happening.

I also removed the `Using Axios` example because imo showing an example with the native [fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch) API is the simplest example for a JS dev to understand and can easily be converted into any http request package that dev decides to use.