### PR TITLE
Dependencies: Specify that jwt must be less than version 4

### DIFF
--- a/omniauth-google-oauth2.gemspec
+++ b/omniauth-google-oauth2.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 2.5'
 
-  gem.add_dependency 'jwt', '>= 2.9.2'
+  gem.add_dependency 'jwt', '>= 2.9.2', '< 4'
   gem.add_dependency 'oauth2', '~> 2.0'
   gem.add_dependency 'omniauth', '~> 2.0'
   gem.add_dependency 'omniauth-oauth2', '~> 1.8'


### PR DESCRIPTION
We know that this gem works with jwt versions 2.x (at least 2.9.2) and 3.x, but we don't know that it will work with jwt 4.x and up, so this PR sets an upper limit on the jwt dependency version.

Fixes #475 